### PR TITLE
Remove newlines from prepended keysets

### DIFF
--- a/frontend/src/Frontend/ReplGhcjs.hs
+++ b/frontend/src/Frontend/ReplGhcjs.hs
@@ -387,10 +387,10 @@ replInner replClick (signingKeys, (code, json)) = mdo
         codeP = mconcat
           [ "(env-data "
           , toJsonString . T.decodeUtf8 . BSL.toStrict $ encode json
-          , ")\n"
+          , ")"
           , "(env-keys ["
           , pactKeys
-          , "])\n\n"
+          , "])"
           , code
           ]
     initState <- liftIO $ initReplState StringEval


### PR DESCRIPTION
The newlines caused the pact errors to have the incorrect line number