### PR TITLE
frontend.cabal: add http-types dependency

### DIFF
--- a/frontend/frontend.cabal
+++ b/frontend/frontend.cabal
@@ -31,6 +31,7 @@ library
                , ghcjs-dom
                , http-client
                , http-client-tls
+               , http-types
                , jsaddle
                , lens
                , megaparsec


### PR DESCRIPTION
This fixes the build failure.