### PR TITLE
Add CORS headers to nginx proxy around pact server

### DIFF
--- a/pact-server/service.nix
+++ b/pact-server/service.nix
@@ -71,5 +71,17 @@ in {pkgs, lib, ...}: {
     };
 
   };
+
+  services.nginx.appendHttpConfig = ''
+      server {
+        location / {
+          if ($request_method = 'POST') {
+             add_header 'Access-Control-Allow-Methods' 'POST';
+             add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+             add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
+          }
+        }
+      }
+  '';
 }
 


### PR DESCRIPTION
@eskimor I deployed 1.1 last night but ran into CORS errors for all requests going to the pact servers.  This change seems to have fixed the problem.  Let's discuss tomorrow whether this is the right change to make.