### PR TITLE
Suggested new comment for example contract

### DIFF
--- a/static/examples/internationalPayments-1.0.repl
+++ b/static/examples/internationalPayments-1.0.repl
@@ -4,6 +4,10 @@
 ;;  for loading this contract!
 ;;
 ;;  Make sure the message is signed with this added key as well.
+;;
+;;  When deploying new contracts, ensure to use a unique keyset
+;;  and unique module from any previously deployed contract
+;;
 ;;---------------------------------
 
 (define-keyset 'module-keyset (read-keyset "keyset"))


### PR DESCRIPTION
@mightybyte — Please take a look at this proposed update to the example contract comments. 

For context: As motivated by the usability problem encountered by new users of the online editor that produces an error message when module and keyset names are already taken by previously deployed contracts.