### PR TITLE
Edit table names in the contract examples

### DIFF
--- a/static/examples/internationalPayments-1.0.repl
+++ b/static/examples/internationalPayments-1.0.repl
@@ -11,42 +11,42 @@
 ;USD Ledger
 (module paymentsUSD 'module-keyset
 
-  (deftable payments-tableUSD)
+  (deftable accounts-tableUSD)
 
   (defun create-accountUSD (id initial-balance)
     "Create a new account for ID with INITIAL-BALANCE funds"
-    (insert payments-tableUSD id { "balance": initial-balance }))
+    (insert accounts-tableUSD id { "balance": initial-balance }))
 
   (defun debitUSD (from amount)
-    (with-read payments-tableUSD from { "balance":= from-bal }
+    (with-read accounts-tableUSD from { "balance":= from-bal }
         (enforce (>= from-bal amount) "Insufficient Funds")
-        (update payments-tableUSD from
+        (update accounts-tableUSD from
                 { "balance": (- from-bal amount) })
         (format "{} debited {}" [from amount])))
 )
 
 ;create USD Ledger table
-(create-table payments-tableUSD)
+(create-table accounts-tableUSD)
 (create-accountUSD "Sarah" 100.00)
 
 ;JPY Ledger
 (module paymentsJPY 'module-keyset
 
-  (deftable payments-tableJPY)
+  (deftable accounts-tableJPY)
 
   (defun create-accountJPY (id initial-balance)
     "Create a new account for ID with INITIAL-BALANCE funds"
-    (insert payments-tableJPY id { "balance": initial-balance }))
+    (insert accounts-tableJPY id { "balance": initial-balance }))
 
   (defun creditJPY (to amount)
-    (with-read payments-tableJPY to { "balance":= to-bal }
-      (update payments-tableJPY to
+    (with-read accounts-tableJPY to { "balance":= to-bal }
+      (update accounts-tableJPY to
               { "balance": (+ to-bal amount) })
       (format "{} credited {}" [to amount])))
 )
 
 ;create JPY Ledger
-(create-table payments-tableJPY)
+(create-table accounts-tableJPY)
 (create-accountJPY "James" 0.0)
 
 ;Cross Border Transfer Specification

--- a/static/examples/simplePayments-1.0.repl
+++ b/static/examples/simplePayments-1.0.repl
@@ -17,23 +17,23 @@
 ;define smart-contract code
 (module payments 'admin-keyset
 
-  (defschema payments
+  (defschema accounts
     balance:decimal
     keyset:keyset)
 
-  (deftable payments-table:{payments})
+  (deftable accounts-table:{payments})
 
   (defun create-account (id initial-balance keyset)
     "Create a new account for ID with INITIAL-BALANCE funds, must be administrator."
     (enforce-keyset 'admin-keyset)
     (enforce (>= initial-balance 0.0) "Initial balances must be >= 0.")
-    (insert payments-table id
+    (insert accounts-table id
             { "balance": initial-balance,
               "keyset": keyset }))
 
   (defun get-balance (id)
     "Only users or admin can read balance."
-    (with-read payments-table id
+    (with-read accounts-table id
       { "balance":= balance, "keyset":= keyset }
       (enforce-one "Access denied"
         [(enforce-keyset keyset)
@@ -41,21 +41,21 @@
       balance))
 
   (defun pay (from to amount)
-    (with-read payments-table from { "balance":= from-bal, "keyset":= keyset }
+    (with-read accounts-table from { "balance":= from-bal, "keyset":= keyset }
       (enforce-keyset keyset)
-      (with-read payments-table to { "balance":= to-bal }
+      (with-read accounts-table to { "balance":= to-bal }
         (enforce (> amount 0.0) "Negative Transaction Amount")
         (enforce (>= from-bal amount) "Insufficient Funds")
-        (update payments-table from
+        (update accounts-table from
                 { "balance": (- from-bal amount) })
-        (update payments-table to
+        (update accounts-table to
                 { "balance": (+ to-bal amount) })
         (format "{} paid {} {}" [from to amount]))))
 
 )
 
 ;define table
-(create-table payments-table)
+(create-table accounts-table)
 
 ;create accounts
 (create-account "Sarah" 100.25 (read-keyset "sarah-keyset"))


### PR DESCRIPTION
- Edited the table names in the sample payment contracts from "payments-table" into "accounts-table"