### PR TITLE
Prevent enter key event if field is invalid

### DIFF
--- a/frontend/src/Frontend/UI/Widgets.hs
+++ b/frontend/src/Frontend/UI/Widgets.hs
@@ -313,16 +313,16 @@ validatedInputWithButton uCls check placeholder buttonText = do
             & inputElementConfig_setValue .~ (T.empty <$ onConfirmed)
             & initialAttributes .~ ("placeholder" =: placeholder <> "type" =: "text" <> "class" =: "new-by-name__input")
         let
-          dInputIsValid = liftA2 (||) nameEmpty checkFailed
+          dInputIsInvalid = liftA2 (||) nameEmpty checkFailed
           nameVal = T.strip <$> _inputElement_value name
-          onEnter = gate (current (not <$> dInputIsValid)) $ keypress Enter name
+          onEnter = gate (current (not <$> dInputIsInvalid)) $ keypress Enter name
           nameEmpty = (== "") <$> nameVal
 
           checkedL = check <*> nameVal
 
         let
           checkFailed = isJust <$> checkedL
-          btnCfg = def & uiButtonCfg_disabled .~ dInputIsValid 
+          btnCfg = def & uiButtonCfg_disabled .~ dInputIsInvalid 
                        & uiButtonCfg_class .~ "button_type_primary" <> "new-by-name__button"
         clicked <- uiButtonDyn btnCfg $ text buttonText
 


### PR DESCRIPTION
The `validatedInputWithButton` function was not gating the enter keypress event like it was with the button click event. This fix ensures that the field must be non-empty and passes the given validation function before either the button will be enabled or the enter event will fire.

Fixes "Disallow creating networks with blank name"