### PR TITLE
Set gas limit minimum and update on post-build

### DIFF
--- a/frontend/src/Frontend/UI/DeploymentSettings.hs
+++ b/frontend/src/Frontend/UI/DeploymentSettings.hs
@@ -361,10 +361,7 @@ uiMetaData m mTTL mGasLimit = do
     onGasLimitTxt <- fmap _inputElement_input $ mkLabeledInput uiIntInputElement "Gas Limit (units)" $ def
       & inputElementConfig_initialValue .~ showGasLimit initGasLimit
       & inputElementConfig_setValue .~ fmap showGasLimit pbGasLimit
-    gasLimit <- holdDyn initGasLimit $ leftmost
-      [ fmapMaybe (readPact (GasLimit . ParsedInteger)) onGasLimitTxt
-      , pbGasLimit
-      ]
+    gasLimit <- holdDyn initGasLimit $ leftmost [fmapMaybe (readPact (GasLimit . ParsedInteger)) onGasLimitTxt, pbGasLimit]
 
     let mkTransactionFee c = uiInputElement $ c
           & initialAttributes %~ Map.insert "disabled" ""


### PR DESCRIPTION
Change the default gas limit to 1000, update the field attributes on the deployment configuration dialog to set the minimum value for this field to be fixed based on network metadata.