### PR TITLE
Fix for loading deployed modules from Module Explorer

### DIFF
--- a/common/src/Common/RefPath.hs
+++ b/common/src/Common/RefPath.hs
@@ -83,15 +83,7 @@ instance IsRefPath Text where
 
 instance IsRefPath Pact.ChainId where
   renderRef = mkRefPath . Pact._chainId
-
-  parseRef = maybe (fail "parseRef ChainId: no parse") (pure . Pact.ChainId) . readMaybe . T.unpack =<< MP.satisfy isWord
-    where
-      isWord :: Text -> Bool
-      isWord = isJust . readWordMay . T.unpack
-
-      readWordMay :: String -> Maybe Word
-      readWordMay = readMaybe
-
+  parseRef = Pact.ChainId <$> anySingle
 
 -- | Try to parse a ref.
 --


### PR DESCRIPTION
A change was made to use the ChainId from Pact, the ChainId in Pact is a newtype over Text
where as the old version wrapped a Word.