### PR TITLE
Make icon always bounce exactly once

### DIFF
--- a/desktop/src/Desktop/Mac.hs
+++ b/desktop/src/Desktop/Mac.hs
@@ -163,8 +163,9 @@ main' ffi mainBundleResourcePath runHTML = redirectPipes [stdout, stderr] $ do
             putMVar signingRequestMVar obj -- handoff to app
             bracket
               (do
+                  res <- _macFFI_global_requestUserAttention ffi
                   _macFFI_moveToForeground ffi
-                  _macFFI_global_requestUserAttention ffi
+                  pure res
               )
               (\r -> do
                   _macFFI_moveToBackground ffi


### PR DESCRIPTION
Looks like there was some weird race condition thing going on with the icon-bouncing + move-to-foreground - I've managed to trigger 3 behaviours:
- bouncing never happens
- bouncing happens once
- bouncing keeps happening (this would keep bouncing even after the app went into background)

I suspect it has to do with whether the app is already in foreground by the time we trigger the bouncing (maybe bringing it to foreground stops the bouncing)

This seems to make the icon always bounce just once - presumably due to the alert being triggered and shortly canceled when the app comes into foreground