### PR TITLE
Enable preview step for Signing API process

### DIFF
--- a/common/src/Common/RefPath.hs
+++ b/common/src/Common/RefPath.hs
@@ -45,7 +45,6 @@ module Common.RefPath
 
 ------------------------------------------------------------------------------
 import           Control.Arrow        (second, (***))
-import           Data.Maybe           (isJust)
 import qualified Data.List            as L
 import qualified Data.List.NonEmpty   as NE
 import           Data.String          (IsString (fromString))
@@ -54,7 +53,6 @@ import qualified Data.Text            as T
 import           Data.Void            (Void)
 import           Text.Megaparsec      as MP
 import qualified Pact.Types.ChainId   as Pact
-import           Text.Read            (readMaybe)
 ------------------------------------------------------------------------------
 
 -- | A path segment is just a piece of `Text`.

--- a/frontend/src/Frontend.hs
+++ b/frontend/src/Frontend.hs
@@ -55,8 +55,8 @@ frontend = Frontend
   , _frontend_body = prerender_ loaderMarkup $ do
     (fileOpened, triggerOpen) <- openFileDialog
 
+    -- TODO: REMOVE! These have been added for testing purposes, remove before merge.
     eSignRq <- (testSignReq <$) <$> button "Trigger Sign Request"
-
     let handleSignResponse e = case e of
           Left err -> logMsg "OH NO:" err
           Right sr -> logMsg "OH YEAH:" (T.pack (show sr))
@@ -77,6 +77,7 @@ frontend = Frontend
       }
   }
   where
+    -- TODO: REMOVE! Added for testing purposes, remove before merge.
     testSignReq =
       let
         Right accname = mkAccountName "doug"

--- a/frontend/src/Frontend.hs
+++ b/frontend/src/Frontend.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE TemplateHaskell  #-}
 module Frontend where
 
+import Control.Lens ((^.))
 import           Control.Monad            (join, void)
 import           Control.Monad.IO.Class
 import           Data.Maybe               (listToMaybe)
@@ -20,6 +21,8 @@ import           Obelisk.Frontend
 import           Obelisk.Route.Frontend
 import           Obelisk.Generated.Static
 
+import Language.Javascript.JSaddle (jsg, js2)
+
 import           Common.Api
 import           Common.Route
 import           Frontend.AppCfg
@@ -27,7 +30,7 @@ import           Frontend.Foundation
 import           Frontend.ModuleExplorer.Impl (loadEditorFromLocalStorage)
 import           Frontend.ReplGhcjs
 import           Frontend.Storage
-
+import Frontend.Wallet (mkAccountName)
 frontend :: Frontend (R FrontendRoute)
 frontend = Frontend
   { _frontend_head = do
@@ -51,6 +54,16 @@ frontend = Frontend
 
   , _frontend_body = prerender_ loaderMarkup $ do
     (fileOpened, triggerOpen) <- openFileDialog
+
+    eSignRq <- (testSignReq <$) <$> button "Trigger Sign Request"
+
+    let handleSignResponse e = case e of
+          Left err -> logMsg "OH NO:" err
+          Right sr -> logMsg "OH YEAH:" (T.pack (show sr))
+          where
+            logMsg :: Text -> Text -> JSM ()
+            logMsg oh a = void $ jsg ("console"::Text) >>= (^. js2 ("log"::Text) oh a)
+
     let store = browserStorage
     flip runStorageT store $ app $ AppCfg
       { _appCfg_gistEnabled = True
@@ -58,12 +71,33 @@ frontend = Frontend
       , _appCfg_openFileDialog = liftJSM triggerOpen
       , _appCfg_loadEditor = loadEditorFromLocalStorage
       , _appCfg_editorReadOnly = False
-      , _appCfg_signingRequest = never
+      , _appCfg_signingRequest = eSignRq
       , _appCfg_signingResponse = \_ -> pure ()
       , _appCfg_forceResize = never
       }
   }
+  where
+    testSignReq =
+      let
+        Right accname = mkAccountName "doug"
+      in
+        SigningRequest
+        -- _signingRequest_code :: Text
+        "(hello-world.greet)"
+        -- _signingRequest_data :: Maybe Aeson.Object
+        Nothing
+        -- _signingRequest_nonce :: Maybe Text
+        (Just "2019-10-10 09:57:30.786580956 UTC")
+        -- _signingRequest_chainId :: Maybe ChainId
+        (Just "0")
+        -- _signingRequest_gasLimit :: Maybe GasLimit
+        (Just 2000)
+        -- _signingRequest_ttl :: Maybe TTLSeconds
+        (Just 34167)
+        -- _signingRequest_sender :: Maybe AccountName
+        (Just accname)
 
+      
 -- | The 'JSM' action *must* be run from a user initiated event in order for the
 -- dialog to open
 openFileDialog :: MonadWidget t m => m (Event t Text, JSM ())

--- a/frontend/src/Frontend.hs
+++ b/frontend/src/Frontend.hs
@@ -64,7 +64,6 @@ frontend = Frontend
       }
   }
 
-      
 -- | The 'JSM' action *must* be run from a user initiated event in order for the
 -- dialog to open
 openFileDialog :: MonadWidget t m => m (Event t Text, JSM ())

--- a/frontend/src/Frontend.hs
+++ b/frontend/src/Frontend.hs
@@ -72,7 +72,7 @@ frontend = Frontend
       , _appCfg_loadEditor = loadEditorFromLocalStorage
       , _appCfg_editorReadOnly = False
       , _appCfg_signingRequest = eSignRq
-      , _appCfg_signingResponse = \_ -> pure ()
+      , _appCfg_signingResponse = handleSignResponse
       , _appCfg_forceResize = never
       }
   }

--- a/frontend/src/Frontend/UI/Dialogs/CallFunction.hs
+++ b/frontend/src/Frontend/UI/Dialogs/CallFunction.hs
@@ -89,7 +89,7 @@ uiCallFunction m mModule func _onClose
             , _deploymentSettingsConfig_gasLimit = Nothing
             }
           pure (cfg, result)
-    fullDeployFlow (headerTitle <> " " <> _pactFunction_name func) m (functionType >> content) _onClose
+    fullDeployFlow (headerTitle <> " " <> _pactFunction_name func) "Preview" m (functionType >> content) _onClose
   | otherwise = do
     onClose <- modalHeader $ do
       text headerTitle

--- a/frontend/src/Frontend/UI/Dialogs/CallFunction.hs
+++ b/frontend/src/Frontend/UI/Dialogs/CallFunction.hs
@@ -50,7 +50,7 @@ import           Frontend.JsonData              (HasJsonData (..), JsonData, Has
 import           Frontend.ModuleExplorer
 import           Frontend.Network
 import           Frontend.UI.DeploymentSettings
-import           Frontend.UI.Dialogs.DeployConfirmation (fullDeployFlow)
+import           Frontend.UI.Dialogs.DeployConfirmation (fullDeployFlow, deployConfirmationConfig_modalTitle)
 import           Frontend.UI.Modal
 import           Frontend.UI.Widgets
 import           Frontend.Wallet                (HasWallet (..))
@@ -89,7 +89,10 @@ uiCallFunction m mModule func _onClose
             , _deploymentSettingsConfig_gasLimit = Nothing
             }
           pure (cfg, result)
-    fullDeployFlow (headerTitle <> " " <> _pactFunction_name func) "Preview" m (functionType >> content) _onClose
+        deployConfirmCfg = def
+          & deployConfirmationConfig_modalTitle .~ (headerTitle <> " " <> _pactFunction_name func)
+
+    fullDeployFlow deployConfirmCfg m (functionType >> content) _onClose
   | otherwise = do
     onClose <- modalHeader $ do
       text headerTitle

--- a/frontend/src/Frontend/UI/Dialogs/DeployConfirmation.hs
+++ b/frontend/src/Frontend/UI/Dialogs/DeployConfirmation.hs
@@ -72,8 +72,8 @@ data DeployConfirmationConfig t = DeployConfirmationConfig
   { _deployConfirmationConfig_modalTitle :: Text
   , _deployConfirmationConfig_previewTitle :: Text
   , _deployConfirmationConfig_previewConfirmButtonLabel :: Text
-    -- The confirmation button the preview screen will be disabled if the network returns
-    -- an error. Some processes like the signing API need to override this as the
+    -- The confirmation button in the preview screen will be disabled if the network
+    -- returns an error. Some processes like the signing API need to override this as the
     -- responsibility for the transaction being signed lies with the creator, not the
     -- person doing the signing. This function will be called twice, once with the bool
     -- value of the status of the network call, and again with the setting for the
@@ -145,7 +145,7 @@ fullDeployFlow deployCfg model runner onClose =
   fullDeployFlowWithSubmit deployCfg model showSubmitModal runner onClose
   where
     showSubmitModal chain result done _next nodes =
-      pure $ attachWith (\n _ -> Right $ deploySubmit chain result n) nodes done
+      pure $ Right . deploySubmit chain result <$> nodes <@ done
 
 -- | Workflow taking the user through Config -> Preview -> Status
 fullDeployFlowWithSubmit

--- a/frontend/src/Frontend/UI/Dialogs/DeployConfirmation.hs
+++ b/frontend/src/Frontend/UI/Dialogs/DeployConfirmation.hs
@@ -361,7 +361,6 @@ deploySubmit chain result nodeInfos = Workflow $ do
         , never
         )
 
-
 -- | Fork a thread. Here because upstream 'forkJSM' doesn't give us the thread ID
 forkJSM' :: JSM () -> JSM ThreadId
 forkJSM' a = askJSM >>= \j -> liftIO $ forkIO $ runJSM a j

--- a/frontend/src/Frontend/UI/Dialogs/Signing.hs
+++ b/frontend/src/Frontend/UI/Dialogs/Signing.hs
@@ -94,4 +94,4 @@ uiSigning appCfg ideL signingRequest onCloseExternal = do
 
       -- This is the end of our work flow, so return our done event on the completion of the signing.
       -- Should some feedback be added to this to ensure that people don't spam the button?
-      fmap Left $ performEvent $ liftJSM . _appCfg_signingResponse appCfg <$> (pure sign <$ next)
+      performEvent $ fmap Left . liftJSM . _appCfg_signingResponse appCfg <$> (pure sign <$ next)

--- a/frontend/src/Frontend/UI/Dialogs/Signing.hs
+++ b/frontend/src/Frontend/UI/Dialogs/Signing.hs
@@ -26,6 +26,7 @@ module Frontend.UI.Dialogs.Signing
 import Reflex
 import Reflex.Dom
 
+import Control.Monad ((<=<))
 import Control.Applicative (liftA2)
 import Frontend.AppCfg
 import Frontend.Foundation hiding (Arg)
@@ -93,14 +94,10 @@ uiSigning appCfg ideL signingRequest onCloseExternal = do
             , _signingResponse_body = _deploymentSettingsResult_command result
             }
 
-          onlyOneOnce a b e = gate (current $ liftA2 (&&) (isZero a) (isZero b)) e
-            where isZero = fmap (== (0 :: Int))
-
-      runOneOnce <- liftA2 onlyOneOnce (count next) (count onCloseExternal)
-
       -- This is the end of our work flow, so return our done event on the completion of the signing.
       -- Should some feedback be added to this to ensure that people don't spam the button?
-      performEvent $ fmap Left . liftJSM . _appCfg_signingResponse appCfg <$> leftmost
-        [ pure sign <$ runOneOnce next
-        , Left "Cancelled" <$ runOneOnce onCloseExternal
+      performEvent . fmap (fmap Left . liftJSM . _appCfg_signingResponse appCfg) <=< headE $ leftmost
+        [ pure sign <$ next
+        , Left "Cancelled" <$ onCloseExternal
         ]
+

--- a/frontend/src/Frontend/UI/Dialogs/Signing.hs
+++ b/frontend/src/Frontend/UI/Dialogs/Signing.hs
@@ -31,6 +31,7 @@ import Frontend.AppCfg
 import Frontend.Foundation hiding (Arg)
 import Frontend.Network
 import Frontend.UI.DeploymentSettings
+import Frontend.UI.Dialogs.DeployConfirmation (fullDeployFlowWithSubmit)
 import Frontend.UI.Modal
 import Frontend.UI.Modal.Impl
 import Frontend.Wallet
@@ -48,29 +49,54 @@ type HasUISigningModelCfg mConf t =
 --
 uiSigning
   :: forall t m mConf
-  . (MonadWidget t m, HasUISigningModelCfg mConf t)
-  => AppCfg t m -> ModalIde m t -> SigningRequest -> Event t () -> m (mConf, Event t ())
+  . ( MonadWidget t m
+    , HasUISigningModelCfg mConf t
+    )
+  => AppCfg t m
+  -> ModalIde m t
+  -> SigningRequest
+  -> Event t ()
+  -> m (mConf, Event t ())
 uiSigning appCfg ideL signingRequest onCloseExternal = do
-  onClose <- modalHeader $ text "Signing Request"
-  (mConf, result, _) <- uiDeploymentSettings ideL $ DeploymentSettingsConfig
-    { _deploymentSettingsConfig_chainId = case _signingRequest_chainId signingRequest of
-      Just c -> predefinedChainIdDisplayed c
-      Nothing -> userChainIdSelect
-    , _deploymentSettingsConfig_defEndpoint = Nothing
-    , _deploymentSettingsConfig_userTab = Nothing
-    , _deploymentSettingsConfig_code = pure $ _signingRequest_code signingRequest
-    , _deploymentSettingsConfig_sender = case _signingRequest_sender signingRequest of
-      Just sender -> \_ _ -> uiSenderFixed sender
-      Nothing -> uiSenderDropdown def
-    , _deploymentSettingsConfig_data = _signingRequest_data signingRequest
-    , _deploymentSettingsConfig_nonce = _signingRequest_nonce signingRequest
-    , _deploymentSettingsConfig_ttl = _signingRequest_ttl signingRequest
-    , _deploymentSettingsConfig_gasLimit = _signingRequest_gasLimit signingRequest
-    }
-  let signed = ffor result $ \r -> SigningResponse
-        { _signingResponse_chainId = _deploymentSettingsResult_chainId r
-        , _signingResponse_body = _deploymentSettingsResult_command r
-        }
-      done = leftmost [Right <$> signed, Left "Cancelled" <$ (onClose <> onCloseExternal)]
-  performEvent_ $ liftJSM . _appCfg_signingResponse appCfg <$> done
-  pure (mConf, void signed <> onClose)
+  let runner = do
+        (mConf, result, _) <- uiDeploymentSettings ideL $ DeploymentSettingsConfig
+          { _deploymentSettingsConfig_chainId = case _signingRequest_chainId signingRequest of
+              Just c -> predefinedChainIdDisplayed c
+              Nothing -> userChainIdSelect
+          , _deploymentSettingsConfig_defEndpoint = Nothing
+          , _deploymentSettingsConfig_userTab = Nothing
+          , _deploymentSettingsConfig_code = pure $ _signingRequest_code signingRequest
+          , _deploymentSettingsConfig_sender = case _signingRequest_sender signingRequest of
+              Just sender -> \_ _ -> uiSenderFixed sender
+              Nothing -> uiSenderDropdown def
+          , _deploymentSettingsConfig_data = _signingRequest_data signingRequest
+          , _deploymentSettingsConfig_nonce = _signingRequest_nonce signingRequest
+          , _deploymentSettingsConfig_ttl = _signingRequest_ttl signingRequest
+          , _deploymentSettingsConfig_gasLimit = _signingRequest_gasLimit signingRequest
+          }
+        pure (mConf, result)
+
+  fullDeployFlowWithSubmit
+    "Signing Request"
+    "Signing Preview"
+    "Confirm Signature"
+    ideL
+    signSubmit
+    runner
+    onCloseExternal
+  where
+    signSubmit chain result done _ = Workflow $ do
+      let sign = SigningResponse
+            { _signingResponse_chainId = _deploymentSettingsResult_chainId result
+            , _signingResponse_body = _deploymentSettingsResult_command result
+            }
+
+      signed <- performEvent $ liftJSM . _appCfg_signingResponse appCfg <$> leftmost
+        [ Right sign <$ done
+        , Left "Cancelled" <$ onCloseExternal
+        ]
+
+      pure
+        ( ("Sign", (signed, mempty))
+        , never
+        )


### PR DESCRIPTION
This extends the deployment workflow to be able to handle the preview step for signing requests and submit the sign on confirm of the preview stage, regardless of the status of the response from the network.

It is still marked as WIP because there are test buttons and data in the UI code to enable investigation of this workflow. They need to be removed before we merge.