### PR TITLE
Change gas payer dropdown to freeform text

### DIFF
--- a/frontend/src/Frontend/AppCfg.hs
+++ b/frontend/src/Frontend/AppCfg.hs
@@ -57,3 +57,7 @@ data AppCfg t m = AppCfg
   , _appCfg_forceResize :: Event t ()
   -- ^ Force the ace widgets to recalculate size
   }
+
+-- Are we running the Kadena Chainweaver ALPHA edition
+isChainweaverAlpha :: Bool
+isChainweaverAlpha = True

--- a/frontend/src/Frontend/UI/DeploymentSettings.hs
+++ b/frontend/src/Frontend/UI/DeploymentSettings.hs
@@ -48,6 +48,7 @@ import           Data.Either                 (rights)
 import           Control.Arrow               ((&&&))
 import           Control.Lens
 import           Control.Monad
+import           Control.Error.Util (hush)
 import qualified Data.Aeson as Aeson
 import qualified Data.Map                    as Map
 import           Data.Set                    (Set)
@@ -522,17 +523,26 @@ uiSenderDropdown
   -> Dynamic t (Maybe ChainId)
   -> m (Dynamic t (Maybe AccountName))
 uiSenderDropdown uCfg m chainId = do
-  let mkTextAccounts mChain chains = case mChain of
-        Nothing -> Map.singleton Nothing "You must select a chain ID before choosing an account"
-        Just chain -> case Map.lookup chain chains of
-          Just accounts | not (Map.null accounts) ->
-            Map.insert Nothing "Choose an account" $ Map.mapKeysMonotonic Just $ Map.mapWithKey (\k _ -> unAccountName k) accounts
-          _ -> Map.singleton Nothing "No accounts on current chain"
-      textAccounts = mkTextAccounts <$> chainId <*> m ^. wallet_accountGuards
-  choice <- dropdown Nothing textAccounts $ uCfg
-    & dropdownConfig_setValue .~ (Nothing <$ updated chainId)
-    & dropdownConfig_attributes <>~ pure ("class" =: "labeled-input__input select select_mandatory_missing select_type_primary")
-  pure $ value choice
+  -- Unused temporarily for ALPHA testing phase
+  -- let mkTextAccounts mChain chains = case mChain of
+  --       Nothing -> Map.singleton Nothing "You must select a chain ID before choosing an account"
+  --       Just chain -> case Map.lookup chain chains of
+  --         Just accounts | not (Map.null accounts) ->
+  --           Map.insert Nothing "Choose an account" $ Map.mapKeysMonotonic Just $ Map.mapWithKey (\k _ -> unAccountName k) accounts
+  --         _ -> Map.singleton Nothing "No accounts on current chain"
+  --     textAccounts = mkTextAccounts <$> chainId <*> m ^. wallet_accountGuards
+  --
+  -- choice <- dropdown Nothing textAccounts $ uCfg
+  --   & dropdownConfig_setValue .~ (Nothing <$ updated chainId)
+  --   & dropdownConfig_attributes <>~ pure ("class" =: "labeled-input__input select select_mandatory_missing select_type_primary")
+  -- pure $ value choice
+
+  fmap (fmap (hush . mkAccountName) . value) $ uiInputElement $ def
+    & inputElementConfig_setValue .~ (mempty <$ updated chainId)
+    & inputElementConfig_elementConfig . elementConfig_initialAttributes .~
+        ("placeholder" =: "Please enter the gas payer account name" <>
+         "style" =: "width:100%"
+        )
 
 -- | Widget (dropdown) for letting the user choose between /send and /local endpoint.
 --

--- a/frontend/src/Frontend/UI/DeploymentSettings.hs
+++ b/frontend/src/Frontend/UI/DeploymentSettings.hs
@@ -77,6 +77,7 @@ import           Frontend.UI.TabBar
 import           Frontend.UI.Widgets
 import           Frontend.UI.Widgets.Helpers (preventScrollWheelAndUpDownArrow)
 import           Frontend.Wallet
+import qualified Frontend.AppCfg as AppCfg
 ------------------------------------------------------------------------------
 
 -- | Config for the deployment settings widget.
@@ -523,7 +524,14 @@ uiSenderDropdown
   -> Dynamic t (Maybe ChainId)
   -> m (Dynamic t (Maybe AccountName))
 uiSenderDropdown uCfg m chainId =
-  if False then do
+  if AppCfg.isChainweaverAlpha then
+    fmap (fmap (hush . mkAccountName) . value) $ uiInputElement $ def
+      & inputElementConfig_setValue .~ (mempty <$ updated chainId)
+      & inputElementConfig_elementConfig . elementConfig_initialAttributes .~
+        ("placeholder" =: "Please enter the gas payer account name" <>
+         "style" =: "width:100%"
+        )
+  else do
     let mkTextAccounts mChain chains = case mChain of
           Nothing -> Map.singleton Nothing "You must select a chain ID before choosing an account"
           Just chain -> case Map.lookup chain chains of
@@ -536,13 +544,6 @@ uiSenderDropdown uCfg m chainId =
       & dropdownConfig_setValue .~ (Nothing <$ updated chainId)
       & dropdownConfig_attributes <>~ pure ("class" =: "labeled-input__input select select_mandatory_missing select_type_primary")
     pure $ value choice
-  else 
-    fmap (fmap (hush . mkAccountName) . value) $ uiInputElement $ def
-      & inputElementConfig_setValue .~ (mempty <$ updated chainId)
-      & inputElementConfig_elementConfig . elementConfig_initialAttributes .~
-        ("placeholder" =: "Please enter the gas payer account name" <>
-         "style" =: "width:100%"
-        )
 
 -- | Widget (dropdown) for letting the user choose between /send and /local endpoint.
 --

--- a/frontend/src/Frontend/UI/DeploymentSettings.hs
+++ b/frontend/src/Frontend/UI/DeploymentSettings.hs
@@ -522,24 +522,24 @@ uiSenderDropdown
   -> model
   -> Dynamic t (Maybe ChainId)
   -> m (Dynamic t (Maybe AccountName))
-uiSenderDropdown uCfg m chainId = do
-  -- Unused temporarily for ALPHA testing phase
-  -- let mkTextAccounts mChain chains = case mChain of
-  --       Nothing -> Map.singleton Nothing "You must select a chain ID before choosing an account"
-  --       Just chain -> case Map.lookup chain chains of
-  --         Just accounts | not (Map.null accounts) ->
-  --           Map.insert Nothing "Choose an account" $ Map.mapKeysMonotonic Just $ Map.mapWithKey (\k _ -> unAccountName k) accounts
-  --         _ -> Map.singleton Nothing "No accounts on current chain"
-  --     textAccounts = mkTextAccounts <$> chainId <*> m ^. wallet_accountGuards
-  --
-  -- choice <- dropdown Nothing textAccounts $ uCfg
-  --   & dropdownConfig_setValue .~ (Nothing <$ updated chainId)
-  --   & dropdownConfig_attributes <>~ pure ("class" =: "labeled-input__input select select_mandatory_missing select_type_primary")
-  -- pure $ value choice
-
-  fmap (fmap (hush . mkAccountName) . value) $ uiInputElement $ def
-    & inputElementConfig_setValue .~ (mempty <$ updated chainId)
-    & inputElementConfig_elementConfig . elementConfig_initialAttributes .~
+uiSenderDropdown uCfg m chainId =
+  if False then do
+    let mkTextAccounts mChain chains = case mChain of
+          Nothing -> Map.singleton Nothing "You must select a chain ID before choosing an account"
+          Just chain -> case Map.lookup chain chains of
+            Just accounts | not (Map.null accounts) ->
+                            Map.insert Nothing "Choose an account" $ Map.mapKeysMonotonic Just $ Map.mapWithKey (\k _ -> unAccountName k) accounts
+            _ -> Map.singleton Nothing "No accounts on current chain"
+        textAccounts = mkTextAccounts <$> chainId <*> m ^. wallet_accountGuards
+  
+    choice <- dropdown Nothing textAccounts $ uCfg
+      & dropdownConfig_setValue .~ (Nothing <$ updated chainId)
+      & dropdownConfig_attributes <>~ pure ("class" =: "labeled-input__input select select_mandatory_missing select_type_primary")
+    pure $ value choice
+  else 
+    fmap (fmap (hush . mkAccountName) . value) $ uiInputElement $ def
+      & inputElementConfig_setValue .~ (mempty <$ updated chainId)
+      & inputElementConfig_elementConfig . elementConfig_initialAttributes .~
         ("placeholder" =: "Please enter the gas payer account name" <>
          "style" =: "width:100%"
         )


### PR DESCRIPTION
Custom change for Chainweaver ALPHA. Reverts the dropdown for the gas payer to a free form text field.