### PR TITLE
Support signing with capabilities

### DIFF
--- a/deps/pact/github.json
+++ b/deps/pact/github.json
@@ -1,7 +1,7 @@
 {
   "owner": "kadena-io",
   "repo": "pact",
-  "branch": "sc-ghc86-merge",
-  "rev": "b220e9d20fcb4ad208b98c2e97668eea5f39b566",
-  "sha256": "0qypr17xxx2djyq6ihrya8nywib78am2aikadh9bhhdxsbghn30c"
+  "branch": "master",
+  "rev": "e7689d1d0474fa019f3cabab0b20b330b25f7673",
+  "sha256": "1y1vg33zq40va06r2n07pzsbv8pc2isqy85q6lhw16kmp89gls0g"
 }

--- a/deps/pact/github.json
+++ b/deps/pact/github.json
@@ -2,6 +2,6 @@
   "owner": "kadena-io",
   "repo": "pact",
   "branch": "master",
-  "rev": "e7689d1d0474fa019f3cabab0b20b330b25f7673",
-  "sha256": "1y1vg33zq40va06r2n07pzsbv8pc2isqy85q6lhw16kmp89gls0g"
+  "rev": "39485fe3271ed25bf30c75ea3a3a157ca4dc482e",
+  "sha256": "1dacarvdw2jivimnpnpz7rs2dgh05wx7nx5im0gys5n3hvgx2dkv"
 }

--- a/deps/pact/github.json
+++ b/deps/pact/github.json
@@ -1,7 +1,7 @@
 {
   "owner": "kadena-io",
   "repo": "pact",
-  "branch": "master",
-  "rev": "39485fe3271ed25bf30c75ea3a3a157ca4dc482e",
-  "sha256": "1dacarvdw2jivimnpnpz7rs2dgh05wx7nx5im0gys5n3hvgx2dkv"
+  "branch": "fix-ghcjs-build",
+  "rev": "70f9afb50d3b42d6e6815938336665330b8fa464",
+  "sha256": "1fzk6iq42c1rajm0jykv861sz8wylzpznfqrgyd98vpfkclfva40"
 }

--- a/deps/servant-github/github.json
+++ b/deps/servant-github/github.json
@@ -1,7 +1,7 @@
 {
-  "owner": "eskimor",
+  "owner": "kadena-io",
   "repo": "servant-github",
   "branch": "rk-quickndirty-ghcjs",
-  "rev": "1875331add7675860751f641e798ea350aa2f3f8",
-  "sha256": "1gy6gbdk7i8iyf663r3qmlv40vvdx9kp6nryyl4qksq3lrvr0fs1"
+  "rev": "f4575b6757caa0e69135f94743c7e82ed9cd9a8e",
+  "sha256": "0lxy1whr25v7fgrhsraw101vrk1dpdwii0dd46a3wwzghmwzily1"
 }

--- a/deps/servant/github.json
+++ b/deps/servant/github.json
@@ -1,7 +1,7 @@
 {
-  "owner": "eskimor",
+  "owner": "haskell-servant",
   "repo": "servant",
-  "branch": "use-ghcjs-dom",
-  "rev": "938405c70ba9a637e22c65fd3b8375d86024720c",
-  "sha256": "1h2s20x9d278ai05j6jkwzw1mq2fmp02skk15h2kzs9bx214lnfx"
+  "branch": "master",
+  "rev": "6e3af85c93ced59419a70ec8b1fd7d8d32e9947b",
+  "sha256": "0n5s3bnw2xdfwdp3dn1py0y7p03v5b6azz1zp3zg6j5d4m3hqw5v"
 }

--- a/deps/servant/github.json
+++ b/deps/servant/github.json
@@ -2,6 +2,6 @@
   "owner": "haskell-servant",
   "repo": "servant",
   "branch": "master",
-  "rev": "6e3af85c93ced59419a70ec8b1fd7d8d32e9947b",
-  "sha256": "0n5s3bnw2xdfwdp3dn1py0y7p03v5b6azz1zp3zg6j5d4m3hqw5v"
+  "rev": "925d50d7526a9b95918b7a2d49e57afa10985302",
+  "sha256": "0zzchj9pc9y50acvj8zbm94bgbvbxzxz2b0xd2zbck90bribwm5b"
 }

--- a/deps/signing-api/default.nix
+++ b/deps/signing-api/default.nix
@@ -1,0 +1,7 @@
+# DO NOT HAND-EDIT THIS FILE
+import ((import <nixpkgs> {}).fetchFromGitHub (
+  let json = builtins.fromJSON (builtins.readFile ./github.json);
+  in { inherit (json) owner repo rev sha256;
+       private = json.private or false;
+     }
+))

--- a/deps/signing-api/github.json
+++ b/deps/signing-api/github.json
@@ -1,7 +1,7 @@
 {
   "owner": "kadena-io",
   "repo": "signing-api",
-  "branch": "fix-record-names",
-  "rev": "22093fce684a09df111f3d3ad9ca1618f22d32f7",
-  "sha256": "0xa9bwp0dyadcixvaayyq8y7b2brfc1bxnv7r73y8qxscpm5d3xj"
+  "branch": "ts-extra-signers",
+  "rev": "09454cc681db9ff95bf2f66a71769ed3720f6951",
+  "sha256": "1hf9gf3ka5vhziw0hwb2kszwjlj5yq8zl8k6lqliclgf26947smv"
 }

--- a/deps/signing-api/github.json
+++ b/deps/signing-api/github.json
@@ -2,6 +2,6 @@
   "owner": "kadena-io",
   "repo": "signing-api",
   "branch": "master",
-  "rev": "a2d66ebdd18061293af320a3d83065ec8108163a",
-  "sha256": "1kypbkc52shcsfd5vb2yjhxhnbx5dx6svi7qpvgh7f3l3wr1lgpf"
+  "rev": "3326b1080f4c20cef53d9e059ebe39161b486501",
+  "sha256": "15wkmzpm48ddc76dq2dia6q2n5dcjh078k03xa9m9fbdbng9s6pk"
 }

--- a/deps/signing-api/github.json
+++ b/deps/signing-api/github.json
@@ -1,7 +1,7 @@
 {
   "owner": "kadena-io",
   "repo": "signing-api",
-  "branch": "master",
-  "rev": "a2d66ebdd18061293af320a3d83065ec8108163a",
-  "sha256": "1kypbkc52shcsfd5vb2yjhxhnbx5dx6svi7qpvgh7f3l3wr1lgpf"
+  "branch": "fix-record-names",
+  "rev": "22093fce684a09df111f3d3ad9ca1618f22d32f7",
+  "sha256": "0xa9bwp0dyadcixvaayyq8y7b2brfc1bxnv7r73y8qxscpm5d3xj"
 }

--- a/deps/signing-api/github.json
+++ b/deps/signing-api/github.json
@@ -2,6 +2,6 @@
   "owner": "kadena-io",
   "repo": "signing-api",
   "branch": "ts-extra-signers",
-  "rev": "09454cc681db9ff95bf2f66a71769ed3720f6951",
-  "sha256": "1hf9gf3ka5vhziw0hwb2kszwjlj5yq8zl8k6lqliclgf26947smv"
+  "rev": "1d79b6e07f5275592d5a44f60c246a278658ddc3",
+  "sha256": "1q63ca5kqhx018s928wfq9l3h2d75g3fhk8f1bn1rxi54zcv1nvh"
 }

--- a/deps/signing-api/github.json
+++ b/deps/signing-api/github.json
@@ -1,0 +1,7 @@
+{
+  "owner": "kadena-io",
+  "repo": "signing-api",
+  "branch": "master",
+  "rev": "a2d66ebdd18061293af320a3d83065ec8108163a",
+  "sha256": "1kypbkc52shcsfd5vb2yjhxhnbx5dx6svi7qpvgh7f3l3wr1lgpf"
+}

--- a/desktop/desktop.cabal
+++ b/desktop/desktop.cabal
@@ -21,6 +21,7 @@ library
     , cryptonite
     , directory
     , filepath
+    , kadena-signing-api
     , jsaddle
     , lens
     , memory

--- a/desktop/desktop.cabal
+++ b/desktop/desktop.cabal
@@ -22,6 +22,7 @@ library
     , directory
     , filepath
     , jsaddle
+    , kadena-signing-api
     , lens
     , memory
     , mtl

--- a/desktop/src/Desktop/Mac.hs
+++ b/desktop/src/Desktop/Mac.hs
@@ -19,6 +19,7 @@ import Foreign.C.String (CString, peekCString)
 import Foreign.C.Types (CInt(..))
 import Foreign.StablePtr (StablePtr)
 import GHC.IO.Handle
+import Kadena.SigningApi
 import Language.Javascript.JSaddle.Types (JSM)
 import Obelisk.Backend
 import Obelisk.Frontend
@@ -103,9 +104,6 @@ backend = Backend
     serve $ serveBackendRoute Nothing cfg'
   , _backend_routeEncoder = backendRouteEncoder
   }
-
-type SigningApi = "v1" :> V1SigningApi
-type V1SigningApi = "sign" :> ReqBody '[JSON] SigningRequest :> Post '[JSON] SigningResponse
 
 main'
   :: MacFFI

--- a/desktop/src/Desktop/Mac.hs
+++ b/desktop/src/Desktop/Mac.hs
@@ -170,7 +170,7 @@ main' ffi mainBundleResourcePath runHTML = redirectPipes [stdout, stderr] $ do
           { Wai.corsRequestHeaders = Wai.simpleHeaders }
         apiServer
           = Warp.runSettings s $ Wai.cors laxCors
-          $ Servant.serve (Proxy @SigningApi) runSign
+          $ Servant.serve signingAPI runSign
     _ <- Async.async $ apiServer
     runHTML "index.html" route putStrLn handleOpen $ do
       mInitFile <- liftIO $ tryTakeMVar fileOpenedMVar

--- a/desktop/src/Desktop/Mac.hs
+++ b/desktop/src/Desktop/Mac.hs
@@ -19,7 +19,7 @@ import Foreign.C.String (CString, peekCString)
 import Foreign.C.Types (CInt(..))
 import Foreign.StablePtr (StablePtr)
 import GHC.IO.Handle
-import Kadena.SigningApi (SigningApi)
+import Kadena.SigningApi (SigningApi, signingAPI)
 import Language.Javascript.JSaddle.Types (JSM)
 import Obelisk.Backend
 import Obelisk.Frontend

--- a/desktop/src/Desktop/Mac.hs
+++ b/desktop/src/Desktop/Mac.hs
@@ -19,6 +19,7 @@ import Foreign.C.String (CString, peekCString)
 import Foreign.C.Types (CInt(..))
 import Foreign.StablePtr (StablePtr)
 import GHC.IO.Handle
+import Kadena.SigningApi (SigningApi)
 import Language.Javascript.JSaddle.Types (JSM)
 import Obelisk.Backend
 import Obelisk.Frontend
@@ -103,9 +104,6 @@ backend = Backend
     serve $ serveBackendRoute Nothing cfg'
   , _backend_routeEncoder = backendRouteEncoder
   }
-
-type SigningApi = "v1" :> V1SigningApi
-type V1SigningApi = "sign" :> ReqBody '[JSON] SigningRequest :> Post '[JSON] SigningResponse
 
 main'
   :: MacFFI

--- a/frontend/frontend.cabal
+++ b/frontend/frontend.cabal
@@ -76,6 +76,7 @@ library
                , transformers
                , trifecta
                , unordered-containers
+               , kadena-signing-api
 
   exposed-modules: Frontend
                  , Frontend.AppCfg

--- a/frontend/frontend.cabal
+++ b/frontend/frontend.cabal
@@ -66,7 +66,7 @@ library
                , safe
                , servant
                , servant-client-core
-               , servant-client-jsaddle
+               , servant-jsaddle
                , servant-github
                , split
                , string-qq

--- a/frontend/src/Frontend.hs
+++ b/frontend/src/Frontend.hs
@@ -59,7 +59,7 @@ frontend = Frontend
       , _appCfg_loadEditor = loadEditorFromLocalStorage
       , _appCfg_editorReadOnly = False
       , _appCfg_signingRequest = never
-      , _appCfg_signingResponse = \_ -> pure ()
+      , _appCfg_signingResponse = liftIO . print
       , _appCfg_forceResize = never
       }
   }

--- a/frontend/src/Frontend/AppCfg.hs
+++ b/frontend/src/Frontend/AppCfg.hs
@@ -1,44 +1,10 @@
 -- | AppCfg is used to configure the app and pass things in and out of reflex
 module Frontend.AppCfg where
 
-import Common.Foundation as Common
 import Data.Text (Text)
 import Language.Javascript.JSaddle (JSM)
 import Reflex.Dom
-import qualified Data.Aeson as Aeson
-import Pact.Types.ChainMeta (TTLSeconds(..))
-import Pact.Types.Runtime (GasLimit(..), ChainId)
-import Pact.Types.Command (Command)
-import Frontend.Wallet (AccountName)
-
-data SigningRequest = SigningRequest
-  { _signingRequest_code :: Text
-  , _signingRequest_data :: Maybe Aeson.Object
-  , _signingRequest_nonce :: Maybe Text
-  , _signingRequest_chainId :: Maybe ChainId
-  , _signingRequest_gasLimit :: Maybe GasLimit
-  , _signingRequest_ttl :: Maybe TTLSeconds
-  , _signingRequest_sender :: Maybe AccountName
-  } deriving (Show, Generic)
-
-instance Aeson.ToJSON SigningRequest where
-  toJSON = Aeson.genericToJSON compactEncoding
-  toEncoding = Aeson.genericToEncoding compactEncoding
-
-instance Aeson.FromJSON SigningRequest where
-  parseJSON = Aeson.genericParseJSON compactEncoding
-
-data SigningResponse = SigningResponse
-  { _signingResponse_body :: Command Text
-  , _signingResponse_chainId :: ChainId
-  } deriving (Eq, Show, Generic)
-
-instance Aeson.ToJSON SigningResponse where
-  toJSON = Aeson.genericToJSON compactEncoding
-  toEncoding = Aeson.genericToEncoding compactEncoding
-
-instance Aeson.FromJSON SigningResponse where
-  parseJSON = Aeson.genericParseJSON compactEncoding
+import Kadena.SigningApi
 
 data AppCfg t m = AppCfg
   { _appCfg_gistEnabled :: Bool

--- a/frontend/src/Frontend/ModuleExplorer/Module.hs
+++ b/frontend/src/Frontend/ModuleExplorer/Module.hs
@@ -153,7 +153,7 @@ functionIsCallable f =
 -- | Get the top level functions from a 'Term'.
 getFunctions :: Term Name -> [PactFunction]
 getFunctions (TModule _ body _) = getFunctions $ Bound.instantiate undefined body
-getFunctions (TDef (Def (DefName name) moduleName defType funType _body meta _) _) =
+getFunctions (TDef (Def (DefName name) moduleName defType funType _body meta _defMeta _info) _) =
   [PactFunction moduleName name defType (_mDocs meta) funType]
 getFunctions (TList list1 _ _) = getFunctions =<< toList list1
 getFunctions _ = []

--- a/frontend/src/Frontend/Network.hs
+++ b/frontend/src/Frontend/Network.hs
@@ -865,13 +865,13 @@ networkRequest baseUri endpoint cmd = do
     runReq :: S.ClientEnv -> S.ClientM a -> ExceptT NetworkError JSM a
     runReq env = reThrowWith packHttpErr . flip S.runClientM env
 
-    packHttpErr :: S.ServantError -> NetworkError
+    packHttpErr :: S.ClientError -> NetworkError
     packHttpErr e = case e of
-      S.FailureResponse response ->
+      S.FailureResponse _ response ->
         if S.responseStatusCode response == HTTP.status413
            then NetworkError_ReqTooLarge
            else NetworkError_Status (S.responseStatusCode response) (T.pack $ show response)
-      S.ConnectionError t -> NetworkError_NetworkError t
+      S.ConnectionError t -> NetworkError_NetworkError (tshow t)
       _ -> NetworkError_Decoding $ T.pack $ show e
 
     fromCommandResult :: MonadError NetworkError m => CommandResult a -> m (Maybe Gas, PactValue)

--- a/frontend/src/Frontend/ReplGhcjs.hs
+++ b/frontend/src/Frontend/ReplGhcjs.hs
@@ -24,54 +24,53 @@
 
 module Frontend.ReplGhcjs where
 
-------------------------------------------------------------------------------
-import           Control.Lens
-import           Control.Monad.Reader                   (ask)
-import           Control.Monad.State.Strict
-import           Data.Default                           (Default (..))
-import qualified Data.Map                               as Map
-import           Data.String                            (IsString)
-import           Data.Text                              (Text)
-import qualified Data.Text                              as T
-import           GHCJS.DOM.EventM                       (on)
-import           GHCJS.DOM.GlobalEventHandlers          (keyPress)
-import           GHCJS.DOM.KeyboardEvent                (getCtrlKey, getKey,
-                                                         getKeyCode, getMetaKey)
-import           GHCJS.DOM.Types                        (HTMLElement (..),
-                                                         unElement)
-import           Language.Javascript.JSaddle            (liftJSM)
-import           Reflex
-import           Reflex.Dom.ACE.Extended                hiding (Annotation (..))
-import           Reflex.Dom.Core
-------------------------------------------------------------------------------
-import           Obelisk.Generated.Static
-import           Obelisk.Route                          (R)
-import           Obelisk.Route.Frontend
-import           Pact.Repl
-import           Pact.Repl.Types
-import           Pact.Types.Lang
-------------------------------------------------------------------------------
-import           Common.OAuth                           (OAuthProvider (OAuthProvider_GitHub))
-import           Common.Route
-import           Frontend.AppCfg
-import           Frontend.Editor
-import           Frontend.Foundation
-import           Frontend.GistStore
-import           Frontend.Ide
-import           Frontend.OAuth
-import           Frontend.Repl
-import           Frontend.Storage
-import           Frontend.UI.Button
-import           Frontend.UI.Dialogs.CreatedGist        (uiCreatedGist)
-import           Frontend.UI.Dialogs.CreateGist         (uiCreateGist)
-import           Frontend.UI.Dialogs.DeployConfirmation (uiDeployConfirmation)
-import           Frontend.UI.Dialogs.LogoutConfirmation (uiLogoutConfirmation)
-import           Frontend.UI.Dialogs.NetworkEdit        (uiNetworkEdit)
-import           Frontend.UI.Dialogs.Signing            (uiSigning)
-import           Frontend.UI.Modal
-import           Frontend.UI.Modal.Impl
-import           Frontend.UI.RightPanel
-------------------------------------------------------------------------------
+import Control.Lens
+import Control.Monad.Reader (ask)
+import Control.Monad.State.Strict
+import Data.Default (Default (..))
+import Data.String (IsString)
+import Data.Text (Text)
+import GHCJS.DOM.EventM (on)
+import GHCJS.DOM.GlobalEventHandlers (keyPress)
+import GHCJS.DOM.KeyboardEvent (getCtrlKey, getKey, getKeyCode, getMetaKey)
+import GHCJS.DOM.Types (HTMLElement (..), unElement)
+import Kadena.SigningApi
+import Language.Javascript.JSaddle (liftJSM)
+import Obelisk.Generated.Static
+import Obelisk.Route (R)
+import Obelisk.Route.Frontend
+import Pact.Repl
+import Pact.Repl.Types
+import Pact.Types.Capability
+import Pact.Types.Lang
+import Pact.Types.PactValue
+import Reflex
+import Reflex.Dom.ACE.Extended hiding (Annotation (..))
+import Reflex.Dom.Core
+import qualified Data.Map as Map
+import qualified Data.Text as T
+
+import Common.OAuth (OAuthProvider (OAuthProvider_GitHub))
+import Common.Route
+import Frontend.AppCfg
+import Frontend.Editor
+import Frontend.Foundation
+import Frontend.GistStore
+import Frontend.Ide
+import Frontend.OAuth
+import Frontend.Repl
+import Frontend.Storage
+import Frontend.UI.Button
+import Frontend.UI.Dialogs.CreateGist (uiCreateGist)
+import Frontend.UI.Dialogs.CreatedGist (uiCreatedGist)
+import Frontend.UI.Dialogs.DeployConfirmation (uiDeployConfirmation)
+import Frontend.UI.Dialogs.LogoutConfirmation (uiLogoutConfirmation)
+import Frontend.UI.Dialogs.NetworkEdit (uiNetworkEdit)
+import Frontend.UI.Dialogs.Signing (uiSigning)
+import Frontend.UI.Modal
+import Frontend.UI.Modal.Impl
+import Frontend.UI.RightPanel
+
 
 app
   :: ( MonadWidget t m

--- a/frontend/src/Frontend/ReplGhcjs.hs
+++ b/frontend/src/Frontend/ReplGhcjs.hs
@@ -34,16 +34,13 @@ import GHCJS.DOM.EventM (on)
 import GHCJS.DOM.GlobalEventHandlers (keyPress)
 import GHCJS.DOM.KeyboardEvent (getCtrlKey, getKey, getKeyCode, getMetaKey)
 import GHCJS.DOM.Types (HTMLElement (..), unElement)
-import Kadena.SigningApi
 import Language.Javascript.JSaddle (liftJSM)
 import Obelisk.Generated.Static
 import Obelisk.Route (R)
 import Obelisk.Route.Frontend
 import Pact.Repl
 import Pact.Repl.Types
-import Pact.Types.Capability
 import Pact.Types.Lang
-import Pact.Types.PactValue
 import Reflex
 import Reflex.Dom.ACE.Extended hiding (Annotation (..))
 import Reflex.Dom.Core

--- a/frontend/src/Frontend/UI/DeploymentSettings.hs
+++ b/frontend/src/Frontend/UI/DeploymentSettings.hs
@@ -687,7 +687,7 @@ uiSenderCapabilities m cid mCaps mkSender = do
   return (firstGASPayer <$> capabilities, capabilities)
   where
     anyGASSigCap :: [SigCapability] -> Bool
-    anyGASSigCap = any (^. to PC._scName . to PN._qnName . to (== "GAS"))
+    anyGASSigCap = any (^. to PC._scName . to PN._qnName . to (== "FUND_TX"))
 
 uiSigningKeys :: (MonadWidget t m, HasWallet model t) => model -> m (Dynamic t (Set KeyName))
 uiSigningKeys model = do
@@ -724,7 +724,7 @@ toggleCheckbox :: Reflex t => Dynamic t Bool -> Event t a -> CheckboxConfig t
 toggleCheckbox val =
   (\v -> def { _checkboxConfig_setValue = v }) . fmap not . tag (current val)
 
--- parsed: "{\"role\": \"GAS\", \"description\": \"Pay the GAS required for this transaction\", \"cap\": {\"args\": [\"doug\",], \"name\": \"coin.GAS\"}}"
+-- parsed: "{\"role\": \"GAS\", \"description\": \"Pay the GAS required for this transaction\", \"cap\": {\"args\": [\"doug\",], \"name\": \"coin.FUND_TX\"}}"
 defaultGASCapability :: DappCap
 defaultGASCapability = DappCap
   { _dappCap_role = "GAS"
@@ -735,8 +735,8 @@ defaultGASCapability = DappCap
         { PN._mnName = "coin"
         , PN._mnNamespace = Nothing
         }
-      , PN._qnName = "GAS"
-      , PN._qnInfo = PI.mkInfo "coin.GAS"
+      , PN._qnName = "FUND_TX"
+      , PN._qnInfo = PI.mkInfo "coin.FUND_TX"
       }
     , PC._scArgs = []
     }

--- a/frontend/src/Frontend/UI/DeploymentSettings.hs
+++ b/frontend/src/Frontend/UI/DeploymentSettings.hs
@@ -64,7 +64,7 @@ import Pact.Types.Capability
 import Pact.Types.ChainMeta (PublicMeta (..), TTLSeconds (..))
 import Pact.Types.PactValue (toPactValue)
 import Pact.Types.Pretty
-import Pact.Types.Runtime (App(..), GasLimit (..), GasPrice (..), PactHash, Name(..), Term(..), hashToText, toUntypedHash, hash)
+import Pact.Types.Runtime (App(..), GasLimit (..), GasPrice (..), Name(..), Term(..), hashToText, toUntypedHash)
 import Reflex
 import Reflex.Dom
 import Reflex.Dom.Contrib.CssClass (elKlass)

--- a/frontend/src/Frontend/UI/DeploymentSettings.hs
+++ b/frontend/src/Frontend/UI/DeploymentSettings.hs
@@ -59,7 +59,7 @@ import Pact.Parse
 import Pact.Types.Capability
 import Pact.Types.ChainMeta (PublicMeta (..), TTLSeconds (..))
 import Pact.Types.Pretty
-import Pact.Types.Runtime (GasLimit (..), GasPrice (..), PactHash, hashToText, toUntypedHash, hash)
+import Pact.Types.Runtime (GasLimit (..), GasPrice (..), hashToText, toUntypedHash)
 import Reflex
 import Reflex.Dom
 import Reflex.Dom.Contrib.CssClass (elKlass)
@@ -69,7 +69,6 @@ import qualified Data.IntMap as IM
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Data.Text as T
-import qualified Data.Text.Encoding as T
 import qualified Pact.Types.ChainId as Pact
 import qualified Pact.Types.Command as Pact
 

--- a/frontend/src/Frontend/UI/DeploymentSettings.hs
+++ b/frontend/src/Frontend/UI/DeploymentSettings.hs
@@ -592,9 +592,9 @@ capabilityInputRow mkSender = elClass "tr" "table__row" $ do
       & modifyAttributes .~ ffor errors (\e -> "style" =: ("background-color: #fdd" <$ guard e))
     empty <- holdUniqDyn $ T.null <$> value cap
     let parsed = parseSigCapability <$> value cap
-        hasError = (\p e -> isLeft p && not e) <$> parsed <*> empty
+        showError = (\p e -> isLeft p && not e) <$> parsed <*> empty
         errors = leftmost
-          [ tag (current hasError) (domEvent Blur cap)
+          [ tag (current showError) (domEvent Blur cap)
           , False <$ _inputElement_input cap
           ]
     pure (empty, parsed)

--- a/frontend/src/Frontend/UI/DeploymentSettings.hs
+++ b/frontend/src/Frontend/UI/DeploymentSettings.hs
@@ -42,6 +42,7 @@ module Frontend.UI.DeploymentSettings
   , Identity (runIdentity)
   ) where
 
+import Control.Applicative (liftA2)
 import Control.Arrow (first, (&&&))
 import Control.Error.Util (hush)
 import Control.Lens
@@ -50,6 +51,7 @@ import Control.Monad.Trans.Class
 import Control.Monad.Trans.Maybe
 import Data.Either (rights, isLeft)
 import Data.IntMap (IntMap)
+import Data.Semigroup (First (..))
 import Data.Map (Map)
 import Data.Set (Set)
 import Data.Text (Text)
@@ -59,7 +61,7 @@ import Pact.Parse
 import Pact.Types.Capability
 import Pact.Types.ChainMeta (PublicMeta (..), TTLSeconds (..))
 import Pact.Types.Pretty
-import Pact.Types.Runtime (GasLimit (..), GasPrice (..), PactHash, hashToText, toUntypedHash, hash)
+import Pact.Types.Runtime (GasLimit (..), GasPrice (..), hashToText, toUntypedHash)
 import Reflex
 import Reflex.Dom
 import Reflex.Dom.Contrib.CssClass (elKlass)
@@ -69,7 +71,6 @@ import qualified Data.IntMap as IM
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Data.Text as T
-import qualified Data.Text.Encoding as T
 import qualified Pact.Types.ChainId as Pact
 import qualified Pact.Types.Command as Pact
 
@@ -86,6 +87,10 @@ import Frontend.UI.Widgets.Helpers (preventScrollWheelAndUpDownArrow)
 import Frontend.Wallet
 import qualified Frontend.AppCfg as AppCfg
 
+import qualified Pact.Types.Capability as PC
+import qualified Pact.Types.Names as PN
+import qualified Pact.Types.Info as PI
+
 -- | Config for the deployment settings widget.
 data DeploymentSettingsConfig t m model a = DeploymentSettingsConfig
   { _deploymentSettingsConfig_userTab     :: Maybe (Text, m a)
@@ -96,7 +101,7 @@ data DeploymentSettingsConfig t m model a = DeploymentSettingsConfig
     --   widget at all, but having `uiDeploymentSettings` use the provided one.
     --
     --   Or you can use `userChainIdSelect` for having the user pick a chainid.
-  , _deploymentSettingsConfig_sender      :: model -> Dynamic t (Maybe ChainId) -> m (Dynamic t (Maybe AccountName))
+  , _deploymentSettingsConfig_sender :: model -> Dynamic t (Maybe ChainId) -> m (Dynamic t (Maybe AccountName))
     -- ^ Sender selection widget. Use 'uiSenderFixed' or 'uiSenderDropdown'.
   , _deploymentSettingsConfig_data        :: Maybe Aeson.Object
     -- ^ Data selection. If 'Nothing', uses the users setting (and allows them
@@ -193,10 +198,7 @@ uiDeploymentSettings m settings = mdo
           (_deploymentSettingsConfig_gasLimit settings)
 
       (mSender, capabilities) <- tabPane mempty curSelection DeploymentSettingsView_Keys $
-        uiSenderCapabilities
-          m
-          cChainId
-          (_deploymentSettingsConfig_caps settings)
+        uiSenderCapabilities m cChainId (_deploymentSettingsConfig_caps settings)
           $ (_deploymentSettingsConfig_sender settings) m cChainId
 
       let result' = runMaybeT $ do
@@ -519,7 +521,7 @@ uiMetaData m mTTL mGasLimit = do
 -- | Set the sender to a fixed value
 uiSenderFixed :: DomBuilder t m => AccountName -> m (Dynamic t (Maybe AccountName))
 uiSenderFixed sender = do
-  _ <- mkLabeledInput uiInputElement "Sender" $ def
+  _ <- uiInputElement $ def
     & initialAttributes %~ Map.insert "disabled" ""
     & inputElementConfig_initialValue .~ unAccountName sender
   pure $ pure $ pure sender
@@ -587,12 +589,17 @@ uiChainSelection info cls = mdo
 -- account to attach
 capabilityInputRow
   :: MonadWidget t m
-  => m (Dynamic t (Maybe AccountName))
+  => Maybe DappCap
+  -> m (Dynamic t (Maybe AccountName))
   -> m (Dynamic t Bool, Dynamic t (Maybe (Map AccountName [SigCapability])))
-capabilityInputRow mkSender = elClass "tr" "table__row" $ do
+capabilityInputRow mCap mkSender = elClass "tr" "table__row" $ do
   (empty, parsed) <- el "td" $ mdo
     cap <- uiInputElement $ def
-      & initialAttributes .~ "placeholder" =: "(module.capability arg1 arg2)" <> "class" =: "input_width_full"
+      & inputElementConfig_initialValue .~ foldMap (renderCompactText . _dappCap_cap) mCap
+      & initialAttributes .~
+        "placeholder" =: "(module.capability arg1 arg2)" <>
+        "class" =: "input_width_full" <>
+        (maybe mempty (const $ "disabled" =: "true") mCap)
       & modifyAttributes .~ ffor errors (\e -> "style" =: ("background-color: #fdd" <$ guard e))
     empty <- holdUniqDyn $ T.null <$> value cap
     let parsed = parseSigCapability <$> value cap
@@ -614,6 +621,7 @@ capabilityInputRow mkSender = elClass "tr" "table__row" $ do
           pure $ ffor ma $ \a -> Map.singleton a (either (const []) pure e)
     )
 
+
 -- | Display a dynamic number of rows for the user to enter custom capabilities
 capabilityInputRows
   :: MonadWidget t m
@@ -621,7 +629,7 @@ capabilityInputRows
   -> m (Dynamic t (Maybe (Map AccountName [SigCapability])))
 capabilityInputRows mkSender = do
   rec
-    (im0, im') <- traverseIntMapWithKeyWithAdjust (\_ _ -> capabilityInputRow mkSender) (IM.singleton 0 ()) $ leftmost
+    (im0, im') <- traverseIntMapWithKeyWithAdjust (\_ _ -> capabilityInputRow Nothing mkSender) (IM.singleton 0 ()) $ leftmost
       -- Delete rows, but ensure we don't delete them all
       [ PatchIntMap <$> gate canDelete deletions
       -- Add a new row when all rows are used
@@ -644,28 +652,42 @@ uiSenderCapabilities
   -> m (Dynamic t (Maybe AccountName))
   -> m (Dynamic t (Maybe AccountName), Dynamic t (Maybe (Map AccountName [SigCapability])))
 uiSenderCapabilities m cid mCaps mkSender = do
-  divClass "title" $ text "Gas Payer"
-  sender <- divClass "group" mkSender
+  let staticCapabilityRow sender cap = do
+        el "td" $ text $ _dappCap_role cap
+        el "td" $ text $ renderCompactText $ _dappCap_cap cap
+        acc <- el "td" $ sender
+        pure $ (fmap . fmap) (\s -> Map.singleton s [_dappCap_cap cap]) acc
+
+  let staticCapabilityRows caps = fmap (fmap (fmap (Map.unionsWith (<>)) . sequence) . sequence) $ for caps $ \cap ->
+        elClass "tr" "table__row" $ staticCapabilityRow (uiSenderDropdown def m cid) cap
+
+  let combineWithRequiredGASPayer gasPayerRow otherCaps =
+        (liftA2 . liftA2) (\mmapA mmapB -> pure $ Map.unionWith (<>) (fold mmapA) (fold mmapB)) gasPayerRow otherCaps
+
+  divClass "title" $ text "Roles"
 
   -- Capabilities
-  -- TODO consider hard coding a single "FUND_TX" / gas field instead of the
-  -- above gas payer input
-  divClass "title" $ text "Roles"
   capabilities <- divClass "group" $ elAttr "table" ("class" =: "table" <> "style" =: "width: 100%") $ case mCaps of
-    Nothing -> el "tbody" $ capabilityInputRows mkSender
+    Nothing -> el "tbody" $ combineWithRequiredGASPayer
+      (snd <$> capabilityInputRow (Just defaultGASCapability) mkSender)
+      (capabilityInputRows (uiSenderDropdown def m cid))
+
     Just caps -> do
       el "thead" $ el "tr" $ do
         elClass "th" "table__heading" $ text "Role"
         elClass "th" "table__heading" $ text "Capability"
         elClass "th" "table__heading" $ text "Account"
-      let fixup = fmap (fmap (Map.unionsWith (<>)) . sequence) . sequence
-      el "tbody" $ fmap fixup $ for caps $ \cap -> elClass "tr" "table__row" $ do
-        el "td" $ text $ _dappCap_role cap
-        el "td" $ text $ renderCompactText $ _dappCap_cap cap
-        acc <- el "td" $ uiSenderDropdown def m cid
-        pure $ fmap (\s -> Map.singleton s [_dappCap_cap cap]) <$> acc
+      el "tbody" $ combineWithRequiredGASPayer
+        (staticCapabilityRow mkSender defaultGASCapability)
+        (staticCapabilityRows caps)
 
-  return (sender, capabilities)
+  let firstGASPayer mmap = fmap getFirst $ 
+        mmap >>= Map.foldMapWithKey (\acc caps -> if anyGASSigCap caps then Just (First acc) else Nothing) 
+  
+  return (firstGASPayer <$> capabilities, capabilities)
+  where
+    anyGASSigCap :: [SigCapability] -> Bool
+    anyGASSigCap = any (^. to PC._scName . to PN._qnName . to (== "GAS"))
 
 uiSigningKeys :: (MonadWidget t m, HasWallet model t) => model -> m (Dynamic t (Set KeyName))
 uiSigningKeys model = do
@@ -701,3 +723,23 @@ signingItem (n, _) = do
 toggleCheckbox :: Reflex t => Dynamic t Bool -> Event t a -> CheckboxConfig t
 toggleCheckbox val =
   (\v -> def { _checkboxConfig_setValue = v }) . fmap not . tag (current val)
+
+-- parsed: "{\"role\": \"GAS\", \"description\": \"Pay the GAS required for this transaction\", \"cap\": {\"args\": [\"doug\",], \"name\": \"coin.GAS\"}}"
+defaultGASCapability :: DappCap
+defaultGASCapability = DappCap
+  { _dappCap_role = "GAS"
+  , _dappCap_description = "Pay the GAS required for this transaction"
+  , _dappCap_cap = PC.SigCapability
+    { PC._scName = PN.QualifiedName
+      { PN._qnQual = PN.ModuleName
+        { PN._mnName = "coin"
+        , PN._mnNamespace = Nothing
+        }
+      , PN._qnName = "GAS"
+      , PN._qnInfo = PI.mkInfo "coin.GAS"
+      }
+    , PC._scArgs = []
+    }
+  }
+
+  

--- a/frontend/src/Frontend/UI/DeploymentSettings.hs
+++ b/frontend/src/Frontend/UI/DeploymentSettings.hs
@@ -42,43 +42,49 @@ module Frontend.UI.DeploymentSettings
   , Identity (runIdentity)
   ) where
 
-------------------------------------------------------------------------------
-import           Control.Arrow               (first)
-import           Data.Either                 (rights)
-import           Control.Arrow               ((&&&))
-import           Control.Lens
-import           Control.Monad
-import           Control.Error.Util (hush)
+import Control.Arrow (first, (&&&))
+import Control.Error.Util (hush)
+import Control.Lens
+import Control.Monad
+import Control.Monad.Trans.Class
+import Control.Monad.Trans.Maybe
+import Data.Either (rights, isLeft)
+import Data.IntMap (IntMap)
+import Data.Map (Map)
+import Data.Set (Set)
+import Data.Text (Text)
+import Data.Traversable (for)
+import Kadena.SigningApi
+import Pact.Parse
+import Pact.Types.Capability
+import Pact.Types.ChainMeta (PublicMeta (..), TTLSeconds (..))
+import Pact.Types.Pretty
+import Pact.Types.Runtime (GasLimit (..), GasPrice (..), PactHash, hashToText, toUntypedHash, hash)
+import Reflex
+import Reflex.Dom
+import Reflex.Dom.Contrib.CssClass (elKlass)
+import Safe (readMay)
 import qualified Data.Aeson as Aeson
-import qualified Data.Map                    as Map
-import           Data.Set                    (Set)
-import           Data.Text                   (Text)
-import qualified Data.Text                   as T
+import qualified Data.IntMap as IM
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
-import           Data.Traversable (for)
-import           Pact.Parse
 import qualified Pact.Types.ChainId as Pact
-import           Pact.Types.ChainMeta        (PublicMeta (..), TTLSeconds (..))
 import qualified Pact.Types.Command as Pact
-import           Pact.Types.Runtime          (GasLimit (..), GasPrice (..), PactHash, hashToText, toUntypedHash, hash)
-import           Reflex
-import           Reflex.Dom
-import           Reflex.Dom.Contrib.CssClass (elKlass)
-import           Safe                        (readMay)
-------------------------------------------------------------------------------
-import           Common.Network
-import           Frontend.Foundation
-import           Frontend.JsonData
-import           Frontend.Network
-import           Frontend.UI.Dialogs.NetworkEdit
-import           Frontend.UI.JsonData
-import           Frontend.UI.Modal
-import           Frontend.UI.TabBar
-import           Frontend.UI.Widgets
-import           Frontend.UI.Widgets.Helpers (preventScrollWheelAndUpDownArrow)
-import           Frontend.Wallet
+
+import Common.Network
+import Frontend.Foundation
+import Frontend.JsonData
+import Frontend.Network
+import Frontend.UI.Dialogs.NetworkEdit
+import Frontend.UI.JsonData
+import Frontend.UI.Modal
+import Frontend.UI.TabBar
+import Frontend.UI.Widgets
+import Frontend.UI.Widgets.Helpers (preventScrollWheelAndUpDownArrow)
+import Frontend.Wallet
 import qualified Frontend.AppCfg as AppCfg
-------------------------------------------------------------------------------
 
 -- | Config for the deployment settings widget.
 data DeploymentSettingsConfig t m model a = DeploymentSettingsConfig
@@ -106,6 +112,8 @@ data DeploymentSettingsConfig t m model a = DeploymentSettingsConfig
     -- ^ TTL. Overridable by the user.
   , _deploymentSettingsConfig_gasLimit :: Maybe GasLimit
     -- ^ Gas Limit. Overridable by the user.
+  , _deploymentSettingsConfig_caps :: Maybe [DappCap]
+    -- ^ Capabilities. When missing, lets the user enter arbitrary capabilities.
   }
 
 data DeploymentSettingsView
@@ -173,7 +181,7 @@ uiDeploymentSettings m settings = mdo
       , _tabBarCfg_classes = mempty
       , _tabBarCfg_type = TabBarType_Secondary
       }
-    (conf, chainId, sender, x, ma) <- elClass "div" "modal__main transaction_details" $ do
+    (conf, result, ma) <- elClass "div" "modal__main transaction_details" $ do
 
       mRes <- traverse (uncurry $ tabPane mempty curSelection) mUserTabCfg
 
@@ -184,39 +192,57 @@ uiDeploymentSettings m settings = mdo
           (_deploymentSettingsConfig_ttl settings)
           (_deploymentSettingsConfig_gasLimit settings)
 
-      (mSender, signingKeys) <- tabPane mempty curSelection DeploymentSettingsView_Keys $
-        uiSigningKeysSender m $ (_deploymentSettingsConfig_sender settings) m cChainId
+      (mSender, capabilities) <- tabPane mempty curSelection DeploymentSettingsView_Keys $
+        uiSenderCapabilities (_deploymentSettingsConfig_caps settings) $ (_deploymentSettingsConfig_sender settings) m cChainId
 
-      pure
-        ( cfg
-        , cChainId
-        , mSender
-        , do
-          signingKeys' <- current signingKeys
-          jsonData' <- either (const mempty) id <$> current (m ^. jsonData . jsonData_data)
-          ttl' <- current ttl
-          gasLimit' <- current gasLimit
-          pm <- current $ m ^. network_meta
-          let publicMeta cid s = pm
-                { _pmChainId = cid
-                , _pmGasLimit = gasLimit'
-                , _pmSender = unAccountName s
-                , _pmTTL = ttl'
+      let result' = runMaybeT $ do
+            networkName <- lift $ m ^. network_selectedNetwork
+            sender <- MaybeT mSender
+            chainId <- MaybeT cChainId
+            caps <- MaybeT capabilities
+            let signing = Set.mapMonotonic unAccountName $ Set.insert sender $ Map.keysSet caps
+            jsonData' <- lift $ either (const mempty) id <$> m ^. jsonData . jsonData_data
+            ttl' <- lift ttl
+            limit <- lift gasLimit
+            lastPublicMeta <- lift $ m ^. network_meta
+            let publicMeta = lastPublicMeta
+                  { _pmChainId = chainId
+                  , _pmGasLimit = limit
+                  , _pmSender = unAccountName sender
+                  , _pmTTL = ttl'
+                  }
+            code' <- lift code
+            mEndpoint <- lift $ sequence cEndpoint
+            keys <- lift $ m ^. wallet_keys
+            let toPublicKey (AccountName acc, cs) = do
+                  KeyPair pk _ <- Map.lookup acc keys
+                  pure (pk, cs)
+                pkCaps = Map.fromList $ fmapMaybe toPublicKey $ Map.toList caps
+            pure $ do
+              let signingPairs = getSigningPairs signing keys
+              cmd <- buildCmd (_deploymentSettingsConfig_nonce settings) networkName publicMeta signingPairs code' jsonData' pkCaps
+              pure $ DeploymentSettingsResult
+                { _deploymentSettingsResult_gasPrice = _pmGasPrice publicMeta
+                , _deploymentSettingsResult_signingKeys = signingPairs
+                , _deploymentSettingsResult_sender = sender
+                , _deploymentSettingsResult_endpoint = mEndpoint
+                , _deploymentSettingsResult_chainId = chainId
+                , _deploymentSettingsResult_command = cmd
+                , _deploymentSettingsResult_code = code'
                 }
-          code' <- current code
-          mEndpoint' <- traverse current cEndpoint
-          allKeys <- current $ m ^. wallet_keys
-          pure (mEndpoint', code', jsonData', signingKeys', allKeys, publicMeta)
+      pure
+        ( cfg & networkCfg_setSender .~ fmapMaybe (fmap unAccountName) (updated mSender)
+        , result'
         , mRes
         )
+    command <- performEvent $ tagMaybe (current result) done
 
     controls <- modalFooter $ do
       let backConfig = def & uiButtonCfg_class .~ ffor curSelection
             (\s -> if s == fromMaybe DeploymentSettingsView_Cfg mUserTabName then "hidden" else "")
       back <- uiButtonDyn backConfig $ text "Back"
-      let shouldBeDisabled tab chain account =
-            tab == DeploymentSettingsView_Keys && (isNothing account || isNothing chain)
-          isDisabled = shouldBeDisabled <$> curSelection <*> chainId <*> sender
+      let shouldBeDisabled tab res = tab == DeploymentSettingsView_Keys && isNothing res
+          isDisabled = shouldBeDisabled <$> curSelection <*> result
       next <- uiButtonDyn (def & uiButtonCfg_class .~ "button_type_confirm" & uiButtonCfg_disabled .~ isDisabled) $ dynText $ ffor curSelection $ \case
         DeploymentSettingsView_Keys -> "Preview"
         _ -> "Next"
@@ -225,24 +251,7 @@ uiDeploymentSettings m settings = mdo
         , prevView mUserTabName <$ back
         ]
 
-    let sign (networkName, Just chain, Just account, (endpoint, code', data', signing, keys, pm)) () = Just $ do
-          let signingKeys = getSigningPairs signing keys
-              pm' = pm chain account
-          cmd <- buildCmd (_deploymentSettingsConfig_nonce settings) networkName pm' signingKeys code' data'
-          pure $ DeploymentSettingsResult
-            { _deploymentSettingsResult_gasPrice = _pmGasPrice pm'
-            , _deploymentSettingsResult_signingKeys = signingKeys
-            , _deploymentSettingsResult_sender = account
-            , _deploymentSettingsResult_endpoint = endpoint
-            , _deploymentSettingsResult_chainId = chain
-            , _deploymentSettingsResult_command = cmd
-            , _deploymentSettingsResult_code = code'
-            }
-        sign _ _ = Nothing
-    command <- performEvent $ attachWithMaybe sign
-      ((,,,) <$> current (m ^. network_selectedNetwork) <*> current chainId <*> current sender <*> x)
-      done
-    pure (conf & networkCfg_setSender .~ fmapMaybe (fmap unAccountName) (updated sender), command, ma)
+    pure (conf, command, ma)
     where
       mUserTabCfg  = first DeploymentSettingsView_Custom <$> _deploymentSettingsConfig_userTab settings
       mUserTabName = fmap fst mUserTabCfg
@@ -311,7 +320,6 @@ uiCfg code m wChainId ep mTTL mGasLimit = do
   let mkGeneralSettings = do
         divClass "title" $ text "Input"
         divClass "group" $ do
-          _ <- mkLabeledInputView (\c -> uiInputElement $ c & initialAttributes %~ Map.insert "disabled" "") "Transaction Hash" $ hashToText . toUntypedHash . id @PactHash . hash . T.encodeUtf8 <$> code
           pb <- getPostBuild
           _ <- flip mkLabeledClsInput "Raw Command" $ \cls -> uiTextAreaElement $ def
             & textAreaElementConfig_setValue .~ leftmost [updated code, tag (current code) pb]
@@ -343,19 +351,18 @@ uiCfg code m wChainId ep mTTL mGasLimit = do
       uiJsonDataSetFocus (\_ _ -> pure ()) (\_ _ -> pure ()) (m ^. wallet) (m ^. jsonData)
   pure $ snd pairA & _1 <>~ snd pairB
 
-transactionHashSection :: MonadWidget t m => Dynamic t Text -> m ()
-transactionHashSection code = void $ do
-  mkLabeledInputView (\c -> uiInputElement $ c & initialAttributes %~ Map.insert "disabled" "") "Transaction Hash" $
-    hashToText . toUntypedHash . id @PactHash . hash . T.encodeUtf8 <$> code
+transactionHashSection :: MonadWidget t m => Pact.Command Text -> m ()
+transactionHashSection cmd = void $ do
+  mkLabeledInput (\c -> uiInputElement $ c & initialAttributes %~ Map.insert "disabled" "") "Transaction Hash" $ def
+    & inputElementConfig_initialValue .~ hashToText (toUntypedHash $ Pact._cmdHash cmd)
 
-transactionInputSection :: MonadWidget t m => Dynamic t Text -> m ()
-transactionInputSection code = do
+transactionInputSection :: MonadWidget t m => Text -> Pact.Command Text -> m ()
+transactionInputSection code cmd = do
   divClass "title" $ text "Input"
   divClass "group" $ do
-    transactionHashSection code
-    pb <- getPostBuild
+    transactionHashSection cmd
     _ <- flip mkLabeledClsInput "Raw Command" $ \cls -> uiTextAreaElement $ def
-      & textAreaElementConfig_setValue .~ leftmost [updated code, tag (current code) pb]
+      & textAreaElementConfig_initialValue .~ code
       & initialAttributes .~ "disabled" =: "" <> "style" =: "width: 100%" <> "class" =: renderClass cls
     pure ()
 
@@ -537,7 +544,7 @@ uiSenderDropdown uCfg m chainId = do
                   _ -> Map.singleton Nothing "No accounts on current chain"
            in mkTextAccounts <$> chainId <*> m ^. wallet_accountGuards
   choice <- dropdown Nothing textAccounts $ uCfg
-    & dropdownConfig_setValue .~ (Nothing <$ updated chainId)
+    & dropdownConfig_setValue .~ (if AppCfg.isChainweaverAlpha then never else Nothing <$ updated chainId)
     & dropdownConfig_attributes <>~ pure ("class" =: "labeled-input__input select select_mandatory_missing select_type_primary")
   pure $ value choice
 
@@ -572,21 +579,87 @@ uiChainSelection info cls = mdo
     d <- _dropdown_value <$> dropdown Nothing (mkOptions <$> chains) cfg
     pure d
 
+-- | Display a single row for the user to enter a custom capability and
+-- account to attach
+capabilityInputRow
+  :: MonadWidget t m
+  => m (Dynamic t (Maybe AccountName))
+  -> m (Dynamic t Bool, Dynamic t (Maybe (Map AccountName [SigCapability])))
+capabilityInputRow mkSender = elClass "tr" "table__row" $ do
+  (empty, parsed) <- el "td" $ mdo
+    cap <- uiInputElement $ def
+      & initialAttributes .~ "placeholder" =: "(module.capability arg1 arg2)" <> "class" =: "input_width_full"
+      & modifyAttributes .~ ffor errors (\e -> "style" =: ("background-color: #fdd" <$ guard e))
+    empty <- holdUniqDyn $ T.null <$> value cap
+    let parsed = parseSigCapability <$> value cap
+        hasError = (\p e -> isLeft p && not e) <$> parsed <*> empty
+        errors = leftmost
+          [ tag (current hasError) (domEvent Blur cap)
+          , False <$ _inputElement_input cap
+          ]
+    pure (empty, parsed)
+  account <- el "td" mkSender
+  pure
+    ( empty
+    , do
+      empty >>= \case
+        True -> pure $ Just mempty
+        False -> do
+          ma <- account
+          e <- parsed
+          pure $ ffor ma $ \a -> Map.singleton a (either (const []) pure e)
+    )
+
+-- | Display a dynamic number of rows for the user to enter custom capabilities
+capabilityInputRows
+  :: MonadWidget t m
+  => m (Dynamic t (Maybe AccountName))
+  -> m (Dynamic t (Maybe (Map AccountName [SigCapability])))
+capabilityInputRows mkSender = do
+  rec
+    (im0, im') <- traverseIntMapWithKeyWithAdjust (\_ _ -> capabilityInputRow mkSender) (IM.singleton 0 ()) $ leftmost
+      -- Delete rows, but ensure we don't delete them all
+      [ PatchIntMap <$> gate canDelete deletions
+      -- Add a new row when all rows are used
+      , attachWith (\i _ -> PatchIntMap (IM.singleton i (Just ()))) nextKeyToUse $ ffilter not $ updated anyEmpty
+      ]
+    results :: Dynamic t (IntMap (Dynamic t Bool, Dynamic t (Maybe (Map AccountName [SigCapability]))))
+      <- foldDyn applyAlways im0 im'
+    let nextKeyToUse = maybe 0 (succ . fst) . IM.lookupMax <$> current results
+        canDelete = (> 1) . IM.size <$> current results
+        anyEmpty = fmap or $ traverse fst =<< results
+        deletions = switch . current $ IM.foldMapWithKey (\i -> (IM.singleton i Nothing <$) . ffilter id . updated . fst) <$> results
+  pure $ fmap (fmap (Map.unionsWith (<>) . IM.elems) . sequence) $ traverse snd =<< results
 
 -- | Widget for selection of sender and signing keys.
-uiSigningKeysSender
-  :: forall t m model. (MonadWidget t m, HasWallet model t)
-  => model
+uiSenderCapabilities
+  :: forall t m. MonadWidget t m
+  => Maybe [DappCap]
   -> m (Dynamic t (Maybe AccountName))
-  -> m (Dynamic t (Maybe AccountName), Dynamic t (Set KeyName))
-uiSigningKeysSender model mkSender = do
+  -> m (Dynamic t (Maybe AccountName), Dynamic t (Maybe (Map AccountName [SigCapability])))
+uiSenderCapabilities mCaps mkSender = do
   divClass "title" $ text "Gas Payer"
-
   sender <- divClass "group" mkSender
 
-  divClass "title" $ text "Transaction Signer"
-  keys <- divClass "group" $ uiSigningKeys model
-  return (sender, keys)
+  -- Capabilities
+  -- TODO consider hard coding a single "FUND_TX" / gas field instead of the
+  -- above gas payer input
+  divClass "title" $ text "Roles"
+  capabilities <- divClass "group" $ elAttr "table" ("class" =: "table" <> "style" =: "width: 100%") $ case mCaps of
+    Nothing -> el "tbody" $ capabilityInputRows mkSender
+    Just caps -> do
+      el "thead" $ el "tr" $ do
+        elClass "th" "table__heading" $ text "Role"
+        elClass "th" "table__heading" $ text "Capability"
+        elClass "th" "table__heading" $ text "Account"
+      let fixup = fmap (fmap (Map.unionsWith (<>)) . sequence) . sequence
+      el "tbody" $ fmap fixup $ for caps $ \cap -> elClass "tr" "table__row" $ do
+        el "td" $ text $ _dappCap_role cap
+        el "td" $ text $ renderCompactText $ _dappCap_cap cap
+        acc <- el "td" mkSender
+        pure $ fmap (\s -> Map.singleton s [_dappCap_cap cap]) <$> acc
+
+  return (sender, capabilities)
 
 uiSigningKeys :: (MonadWidget t m, HasWallet model t) => model -> m (Dynamic t (Set KeyName))
 uiSigningKeys model = do

--- a/frontend/src/Frontend/UI/DeploymentSettings.hs
+++ b/frontend/src/Frontend/UI/DeploymentSettings.hs
@@ -694,9 +694,7 @@ uiSenderCapabilities m cid mCaps mkSender = do
   divClass "group" $ elAttr "table" ("class" =: "table" <> "style" =: "width: 100%") $ case mCaps of
     Nothing -> el "tbody" $ do
       gas <- capabilityInputRow (Just defaultGASCapability) mkSender
-      display $ _capabilityInputRow_value gas
       rest <- capabilityInputRows (uiSenderDropdown def m cid)
-      display rest
       pure (_capabilityInputRow_account gas, combineMaps (_capabilityInputRow_value gas) rest)
     Just caps -> do
       el "thead" $ el "tr" $ do

--- a/frontend/src/Frontend/UI/DeploymentSettings.hs
+++ b/frontend/src/Frontend/UI/DeploymentSettings.hs
@@ -119,6 +119,9 @@ data DeploymentSettingsConfig t m model a = DeploymentSettingsConfig
     -- ^ Gas Limit. Overridable by the user.
   , _deploymentSettingsConfig_caps :: Maybe [DappCap]
     -- ^ Capabilities. When missing, lets the user enter arbitrary capabilities.
+  , _deploymentSettingsConfig_extraSigners :: [PublicKey]
+    -- ^ Extra signers to be added to the command. The dApp should fill in the
+    -- signatures as required upon receiving the response.
   }
 
 data DeploymentSettingsView
@@ -226,7 +229,11 @@ uiDeploymentSettings m settings = mdo
                 pkCaps = Map.fromList $ fmapMaybe toPublicKey $ Map.toList caps
             pure $ do
               let signingPairs = getSigningPairs signing keys
-              cmd <- buildCmd (_deploymentSettingsConfig_nonce settings) networkName publicMeta signingPairs code' jsonData' pkCaps
+              cmd <- buildCmd
+                (_deploymentSettingsConfig_nonce settings)
+                networkName publicMeta signingPairs
+                (_deploymentSettingsConfig_extraSigners settings)
+                code' jsonData' pkCaps
               pure $ DeploymentSettingsResult
                 { _deploymentSettingsResult_gasPrice = _pmGasPrice publicMeta
                 , _deploymentSettingsResult_signingKeys = signingPairs

--- a/frontend/src/Frontend/UI/Dialogs/CallFunction.hs
+++ b/frontend/src/Frontend/UI/Dialogs/CallFunction.hs
@@ -88,6 +88,7 @@ uiCallFunction m mModule func _onClose
             , _deploymentSettingsConfig_nonce = Nothing
             , _deploymentSettingsConfig_gasLimit = Nothing
             , _deploymentSettingsConfig_caps = Nothing
+            , _deploymentSettingsConfig_extraSigners = []
             }
           pure (cfg, result)
         deployConfirmCfg = def

--- a/frontend/src/Frontend/UI/Dialogs/CallFunction.hs
+++ b/frontend/src/Frontend/UI/Dialogs/CallFunction.hs
@@ -87,6 +87,7 @@ uiCallFunction m mModule func _onClose
             , _deploymentSettingsConfig_ttl = Nothing
             , _deploymentSettingsConfig_nonce = Nothing
             , _deploymentSettingsConfig_gasLimit = Nothing
+            , _deploymentSettingsConfig_caps = Nothing
             }
           pure (cfg, result)
         deployConfirmCfg = def

--- a/frontend/src/Frontend/UI/Dialogs/DeployConfirmation.hs
+++ b/frontend/src/Frontend/UI/Dialogs/DeployConfirmation.hs
@@ -127,6 +127,7 @@ uiDeployConfirmation code model = fullDeployFlow def model $ do
     , _deploymentSettingsConfig_nonce = Nothing
     , _deploymentSettingsConfig_gasLimit = Nothing
     , _deploymentSettingsConfig_caps = Nothing
+    , _deploymentSettingsConfig_extraSigners = []
     }
   pure (settingsCfg, result)
 

--- a/frontend/src/Frontend/UI/Dialogs/DeployConfirmation.hs
+++ b/frontend/src/Frontend/UI/Dialogs/DeployConfirmation.hs
@@ -59,7 +59,6 @@ import Reflex.Extended (tagOnPostBuild)
 import Reflex.Network.Extended (Flattenable)
 import Reflex.Network.Extended (flatten)
 import qualified Data.Map as Map
-import qualified Data.Map.Merge.Lazy as Map
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Pact.Server.ApiV1Client as Api
@@ -274,7 +273,6 @@ deploySubmit
   -> Workflow t m (Text, (Event t (), modelCfg))
 deploySubmit chain result nodeInfos = Workflow $ do
       let cmd = _deploymentSettingsResult_command result
-          code = _deploymentSettingsResult_code result
       elClass "div" "modal__main transaction_details" $ do
         transactionHashSection cmd
 
@@ -323,7 +321,7 @@ deploySubmit chain result nodeInfos = Workflow $ do
                 Just (Api.ListenTimeout _i) -> listen Status_Failed
                 Just (Api.ListenResponse commandResult) -> case (Pact._crTxId commandResult, Pact._crResult commandResult) of
                   -- We should always have a txId when we have a result
-                  (Just txId, Pact.PactResult (Right a)) -> do
+                  (Just _txId, Pact.PactResult (Right a)) -> do
                     listen Status_Done
                     setMessage $ Just $ Right a
                     -- TODO wait for confirmation...

--- a/frontend/src/Frontend/UI/Dialogs/DeployConfirmation.hs
+++ b/frontend/src/Frontend/UI/Dialogs/DeployConfirmation.hs
@@ -127,6 +127,7 @@ uiDeployConfirmation code model = fullDeployFlow def model $ do
     , _deploymentSettingsConfig_ttl = Nothing
     , _deploymentSettingsConfig_nonce = Nothing
     , _deploymentSettingsConfig_gasLimit = Nothing
+    , _deploymentSettingsConfig_caps = Nothing
     }
   pure (settingsCfg, result)
 
@@ -181,7 +182,7 @@ fullDeployFlowWithSubmit dcfg model onPreviewConfirm runner _onClose = do
           sender = _deploymentSettingsResult_sender result
       succeeded <- elClass "div" "modal__main transaction_details" $ do
 
-        transactionInputSection $ pure $ _deploymentSettingsResult_code result
+        transactionInputSection (_deploymentSettingsResult_code result) (_deploymentSettingsResult_command result)
         divClass "title" $ text "Destination"
         _ <- divClass "group segment" $ do
           transactionDisplayNetwork model
@@ -278,7 +279,7 @@ deploySubmit chain result nodeInfos = Workflow $ do
       let cmd = _deploymentSettingsResult_command result
           code = _deploymentSettingsResult_code result
       elClass "div" "modal__main transaction_details" $ do
-        transactionHashSection $ pure code
+        transactionHashSection cmd
 
         -- Shove the node infos into servant client envs
         clientEnvs <- fmap catMaybes $ for (rights nodeInfos) $ \nodeInfo -> do

--- a/frontend/src/Frontend/UI/Dialogs/Signing.hs
+++ b/frontend/src/Frontend/UI/Dialogs/Signing.hs
@@ -75,7 +75,7 @@ uiSigning appCfg ideL signingRequest onCloseExternal = do
           , _deploymentSettingsConfig_ttl = _signingRequest_ttl signingRequest
           , _deploymentSettingsConfig_gasLimit = _signingRequest_gasLimit signingRequest
           , _deploymentSettingsConfig_caps = Just $ _signingRequest_caps signingRequest
-          , _deploymentSettingsConfig_extraSigners = fromPactPublicKey <$> _signingRequest_extraSigners signingRequest
+          , _deploymentSettingsConfig_extraSigners = fromPactPublicKey <$> fromMaybe [] (_signingRequest_extraSigners signingRequest)
           }
         pure (mConf, result)
 

--- a/frontend/src/Frontend/UI/Dialogs/Signing.hs
+++ b/frontend/src/Frontend/UI/Dialogs/Signing.hs
@@ -29,6 +29,7 @@ import Reflex
 import Reflex.Dom
 
 import Frontend.AppCfg
+import Frontend.Crypto.Ed25519 (fromPactPublicKey)
 import Frontend.Foundation hiding (Arg)
 import Frontend.JsonData
 import Frontend.Network
@@ -74,6 +75,7 @@ uiSigning appCfg ideL signingRequest onCloseExternal = do
           , _deploymentSettingsConfig_ttl = _signingRequest_ttl signingRequest
           , _deploymentSettingsConfig_gasLimit = _signingRequest_gasLimit signingRequest
           , _deploymentSettingsConfig_caps = Just $ _signingRequest_caps signingRequest
+          , _deploymentSettingsConfig_extraSigners = fromPactPublicKey <$> _signingRequest_extraSigners signingRequest
           }
         pure (mConf, result)
 

--- a/frontend/src/Frontend/UI/Dialogs/Signing.hs
+++ b/frontend/src/Frontend/UI/Dialogs/Signing.hs
@@ -23,7 +23,7 @@ module Frontend.UI.Dialogs.Signing
   ( uiSigning
   ) where
 
-import Control.Monad ((<=<), void)
+import Control.Monad ((<=<))
 import Kadena.SigningApi
 import Reflex
 import Reflex.Dom

--- a/frontend/src/Frontend/UI/Dialogs/Signing.hs
+++ b/frontend/src/Frontend/UI/Dialogs/Signing.hs
@@ -23,7 +23,7 @@ module Frontend.UI.Dialogs.Signing
   ( uiSigning
   ) where
 
-import Control.Monad ((<=<))
+import Control.Monad ((<=<), void)
 import Kadena.SigningApi
 import Reflex
 import Reflex.Dom
@@ -77,12 +77,18 @@ uiSigning appCfg ideL signingRequest onCloseExternal = do
           }
         pure (mConf, result)
 
-  fullDeployFlowWithSubmit
+
+  (conf, done) <- fullDeployFlowWithSubmit
     (DeployConfirmationConfig "Signing Request" "Signing Preview" "Confirm Signature" disregardSuccessStatus)
     ideL
     signSubmit
     runner
     onCloseExternal
+
+  finished <- performEvent . fmap (liftJSM . _appCfg_signingResponse appCfg) <=< headE $
+    maybe (Left "Cancelled") Right <$> leftmost [done, Nothing <$ onCloseExternal]
+
+  pure (conf, finished)
   where
     -- The confirm process should proceed regardless of the response from the network, the
     -- failure of this is the responsibility of the dApp. This ensures the confirm button
@@ -94,11 +100,7 @@ uiSigning appCfg ideL signingRequest onCloseExternal = do
             { _signingResponse_chainId = _deploymentSettingsResult_chainId result
             , _signingResponse_body = _deploymentSettingsResult_command result
             }
-
       -- This is the end of our work flow, so return our done event on the completion of the signing.
       -- Should some feedback be added to this to ensure that people don't spam the button?
-      performEvent . fmap (fmap Left . liftJSM . _appCfg_signingResponse appCfg) <=< headE $ leftmost
-        [ pure sign <$ next
-        , Left "Cancelled" <$ onCloseExternal
-        ]
+      pure $ Left sign <$ next
 

--- a/frontend/src/Frontend/UI/Dialogs/Signing.hs
+++ b/frontend/src/Frontend/UI/Dialogs/Signing.hs
@@ -23,19 +23,19 @@ module Frontend.UI.Dialogs.Signing
   ( uiSigning
   ) where
 
+import Control.Monad ((<=<))
+import Kadena.SigningApi
 import Reflex
 import Reflex.Dom
 
-import Control.Monad ((<=<))
-import Control.Applicative (liftA2)
 import Frontend.AppCfg
 import Frontend.Foundation hiding (Arg)
+import Frontend.JsonData
 import Frontend.Network
 import Frontend.UI.DeploymentSettings
 import Frontend.UI.Dialogs.DeployConfirmation (DeployConfirmationConfig (..), fullDeployFlowWithSubmit)
 import Frontend.UI.Modal.Impl
 import Frontend.Wallet
-import Frontend.JsonData
 
 type HasUISigningModelCfg mConf t =
   ( Monoid mConf, Flattenable mConf t, HasWalletCfg mConf t
@@ -73,6 +73,7 @@ uiSigning appCfg ideL signingRequest onCloseExternal = do
           , _deploymentSettingsConfig_nonce = _signingRequest_nonce signingRequest
           , _deploymentSettingsConfig_ttl = _signingRequest_ttl signingRequest
           , _deploymentSettingsConfig_gasLimit = _signingRequest_gasLimit signingRequest
+          , _deploymentSettingsConfig_caps = Just $ _signingRequest_caps signingRequest
           }
         pure (mConf, result)
 

--- a/frontend/src/Frontend/Wallet.hs
+++ b/frontend/src/Frontend/Wallet.hs
@@ -38,27 +38,28 @@ module Frontend.Wallet
   , checkKeyNameValidityStr
   ) where
 
-import           Control.Lens
-import           Control.Monad.Except (runExcept)
-import           Control.Monad.Fix
-import           Data.Aeson
-import           Data.Map                    (Map)
-import qualified Data.Map                    as Map
-import           Data.Set                    (Set)
-import qualified Data.Set                    as Set
-import           Data.Text                   (Text)
-import qualified Data.Text                   as T
-import           Generics.Deriving.Monoid    (mappenddefault, memptydefault)
-import           GHC.Generics                (Generic)
-import           Reflex
-import           Pact.Types.ChainId
-import qualified Pact.Types.Term             as Pact
-import qualified Pact.Types.Type             as Pact
+import Control.Lens
+import Control.Monad.Except (runExcept)
+import Control.Monad.Fix
+import Data.Aeson
+import Data.Map (Map)
+import Data.Set (Set)
+import Data.Text (Text)
+import GHC.Generics (Generic)
+import Generics.Deriving.Monoid (mappenddefault, memptydefault)
+import Kadena.SigningApi (AccountName(..), mkAccountName)
+import Pact.Types.ChainId
+import Reflex
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+import qualified Data.Text as T
+import qualified Pact.Types.Term as Pact
+import qualified Pact.Types.Type as Pact
 
-import           Common.Orphans              ()
-import           Frontend.Crypto.Ed25519
-import           Frontend.Foundation
-import           Frontend.Storage
+import Common.Orphans ()
+import Frontend.Crypto.Ed25519
+import Frontend.Foundation
+import Frontend.Storage
 
 -- | Type of a `Key` name.
 --
@@ -76,17 +77,6 @@ makePactLenses ''KeyPair
 
 -- | `KeyName` to `Key` mapping
 type KeyPairs = Map KeyName KeyPair
-
-newtype AccountName = AccountName
-  { unAccountName :: Text
-  } deriving (Eq, Ord, Show, ToJSON, FromJSON, ToJSONKey, FromJSONKey)
-
--- | Smart constructor for account names. The only restriction in the coin
--- contract (as it stands) appears to be that accounts can't be an empty string
-mkAccountName :: Text -> Either Text AccountName
-mkAccountName n
-  | T.null n = Left "Account name must not be empty"
-  | otherwise = Right $ AccountName n
 
 -- | Account guards. We split this out here because we are only really
 -- interested in keyset guards right now. Someday we might end up replacing this

--- a/obApp.nix
+++ b/obApp.nix
@@ -92,7 +92,7 @@ in
         pact = haskellLib.dontCheck super.pact; # tests can timeout...
       };
     in self: super: lib.foldr lib.composeExtensions (_: _: {}) [
-      (import (hackGet ./deps/pact + "/overrides.nix") pkgs)
+      (import (hackGet ./deps/pact + "/overrides.nix") pkgs hackGet)
       desktop-overlay
       common-overlay
       (optionalExtension (super.ghc.isGhcjs or false) guard-ghcjs-overlay)

--- a/obApp.nix
+++ b/obApp.nix
@@ -21,8 +21,9 @@ in
     __closureCompilerOptimizationLevel = "SIMPLE";
 
     shellToolOverrides = ghc: super: {
-         z3 = pkgs.z3;
-       };
+      z3 = pkgs.z3;
+      ghcid = pkgs.haskell.lib.justStaticExecutables super.ghcid; #https://github.com/reflex-frp/reflex-platform/pull/548
+     };
    packages =
      let
        servantSrc = hackGet ./deps/servant;

--- a/obApp.nix
+++ b/obApp.nix
@@ -41,6 +41,7 @@ in
           # Needed for obelisk-oauth currently (ghcjs support mostly):
           entropy = hackGet ./deps/entropy;
           cardano-crypto = hackGet ./deps/cardano-crypto;
+          kadena-signing-api = hackGet ./deps/signing-api + /kadena-signing-api;
           desktop = ./desktop;
           mac = builtins.filterSource (path: type: !(builtins.elem (baseNameOf path) ["static"])) ./mac;
       };

--- a/obApp.nix
+++ b/obApp.nix
@@ -31,7 +31,7 @@ in
           pact = hackGet ./deps/pact;
           # servant-client-core = servantSrc + "/servant-client-core";
           # servant = servantSrc + "/servant";
-          servant-client-jsaddle = servantSrc + "/servant-client-jsaddle";
+          servant-jsaddle = servantSrc + "/servant-jsaddle";
           reflex-dom-ace = hackGet ./deps/reflex-dom-ace;
           reflex-dom-contrib = hackGet ./deps/reflex-dom-contrib;
           servant-github = hackGet ./deps/servant-github;
@@ -72,14 +72,7 @@ in
         wai-app-static = haskellLib.dontCheck super.wai-app-static;
         servant-client = haskellLib.dontCheck super.servant-client;
 
-        # hw-hspec-hedgehog doesn't work
-        # pact = haskellLib.dontCheck super.pact;
-
         unliftio = haskellLib.dontCheck super.unliftio;
-        # prettyprinter-ansi-terminal = haskellLib.dontCheck (haskellLib.dontHaddock super.prettyprinter-ansi-terminal);
-        # prettyprinter-convert-ansi-wl-pprint = haskellLib.dontCheck (haskellLib.dontHaddock super.prettyprinter-convert-ansi-wl-pprint);
-
-        # servant-github = haskellLib.dontCheck super.servant-github;
       };
       common-overlay = self: super:
         let
@@ -90,20 +83,12 @@ in
                 inherit sha256;
               }) {};
         in {
-
-        # nixpkgs has a bad hash for this
-        # https://github.com/NixOS/nixpkgs/issues/65400
-        servant = callHackageDirect {
-          pkg = "servant";
-          ver = "0.15";
-          sha256 = "1d9bm5wgpk2czx240d7fd6k0mhhj52406gmj7vwpfcwrm7fg0w5v";
-        };
-
         ghc-lib-parser = haskellLib.overrideCabal super.ghc-lib-parser { postInstall = "sed -i 's/exposed: True/exposed: False/' $out/lib/ghc*/package.conf.d/*.conf"; };
-        pact = haskellLib.dontCheck super.pact; # TODO don't do this
+        reflex-dom-core = haskellLib.dontCheck super.reflex-dom-core; # webdriver fails to build
         modern-uri = haskellLib.dontCheck super.modern-uri;
-        servant-client-jsaddle = haskellLib.dontCheck (haskellLib.doJailbreak super.servant-client-jsaddle);
+        servant-jsaddle = haskellLib.dontCheck (haskellLib.doJailbreak super.servant-jsaddle);
         obelisk-oauth-frontend = haskellLib.doJailbreak super.obelisk-oauth-frontend;
+        pact = haskellLib.dontCheck super.pact; # tests can timeout...
       };
     in self: super: lib.foldr lib.composeExtensions (_: _: {}) [
       (import (hackGet ./deps/pact + "/overrides.nix") pkgs)


### PR DESCRIPTION
Adds support for capabilities. The signing API passes all capabilities
it needs, and these are displayed to the user with an account dropdown
box. Other deployment methods allow the user to specify arbitrary
capabilities.

The sender/gas payer field has not been altered here, but in future
could be moved to the capabilities/roles section too.

This also fixes the transaction hash stuff in deployment dialogs. We
were hashing the code, not the command.

### **Don't merge this yet, this isn't a guaranteed change upstream**