### PR TITLE
Fix warnings

### DIFF
--- a/desktop/src/Desktop/Mac.hs
+++ b/desktop/src/Desktop/Mac.hs
@@ -13,19 +13,16 @@ import Control.Monad (forever)
 import Control.Monad.Except (throwError)
 import Control.Monad.IO.Class
 import Data.Foldable (for_)
-import Data.Proxy (Proxy(..))
 import Data.String (IsString(..))
 import Foreign.C.String (CString, peekCString)
-import Foreign.C.Types (CInt(..))
 import Foreign.StablePtr (StablePtr)
 import GHC.IO.Handle
-import Kadena.SigningApi (SigningApi, signingAPI)
+import Kadena.SigningApi (signingAPI)
 import Language.Javascript.JSaddle.Types (JSM)
 import Obelisk.Backend
 import Obelisk.Frontend
 import Obelisk.Route.Frontend
 import Reflex.Dom
-import Servant.API
 import System.FilePath ((</>))
 import System.IO
 import qualified Control.Concurrent.Async as Async


### PR DESCRIPTION
I get a lot of
```
src/Desktop/Setup.hs:118:6: warning: [-Wsimplifiable-class-constraints]
    • The constraint ‘MonadWidget t m’ matches an instance declaration
      instance Reflex.Dom.Old.MonadWidgetConstraints t m =>
               MonadWidget t m
        -- Defined in ‘Reflex.Dom.Old’
      This makes type inference for inner bindings fragile;
        either use MonoLocalBinds, or simplify it using the instance
    • In the type signature:
        createNewWallet :: MonadWidget t m =>
                           Maybe (Crypto.MnemonicSentence 15) -> SetupWF t m
```
only in this module for some reason. Rather than figure it out, I just used more granular constraints