### PR TITLE
Simplify dirty check on password form for wallet setup

### DIFF
--- a/desktop/src/Desktop/Setup.hs
+++ b/desktop/src/Desktop/Setup.hs
@@ -523,7 +523,7 @@ setPassword dSeed = form "" $ do
   p1Dirty <- holdUniqDyn =<< holdDyn False (True <$ _inputElement_input p1elem)
   p2Dirty <- holdUniqDyn =<< holdDyn False (True <$ _inputElement_input p2elem)
 
-  let inputsDirty = current $ liftA2 (&&) p1Dirty p2Dirty
+  let inputsDirty = current $ liftA2 (||) p1Dirty p2Dirty
 
   eCheckPassword <- fmap (gate inputsDirty) $ delay 0.2 $ leftmost
     [ _inputElement_input p1elem


### PR DESCRIPTION
This makes the dirty check easier to satisfy and the feedback from the password checks happens faster. Instead of waiting for both fields to have input before checking if the original password input meets the requirements.

This should have been included in #188 but for some reason the commit didn't make it in.