### PR TITLE
feat: Adds the resources page

### DIFF
--- a/backend/sass/common.blocks/_resources.scss
+++ b/backend/sass/common.blocks/_resources.scss
@@ -1,0 +1,62 @@
+/*********************************************************************************
+   Ensure classes and structure are created in accordance with the BEM methodology.
+   For more info: https://en.bem.info/methodology/quick-start/
+
+*********************************************************************************/
+
+@import '../include/defs';
+
+.resources {
+  display: flex;
+}
+
+.resources__cell {
+  display: block;
+  text-decoration: none;
+  margin: $medium-margin;
+  width: 420px;
+  &:first-child {
+    margin-left: $double-margin;
+  }
+  &:visited {
+    color: $black;
+  }
+}
+
+
+.resources__cell-icon {
+  background-color: #454444;
+  border-radius: 50%;
+  width: 130px;
+  height: 130px;
+  background-position: 50% 50%;
+  background-repeat: no-repeat;
+  margin: $double-margin auto;
+}
+
+.resources__cell-header {
+  border-color: $std-border-color;
+  border-style: $std-border-style;
+  border-width: $std-border-width;
+  border-radius: $std-border-radius;
+  text-align: center;
+  padding: $bigger-padding;
+  font-size: 18px;
+}
+
+.resources__cell-launch {
+  position: relative;
+  top: 3px;
+  right: 5px;
+  height: 18px;
+}
+
+.resources__cell-title {
+}
+
+.resources__cell-desc {
+  text-align: center;
+  color: $tertiary-color;
+  padding: $normal-padding;
+  font-size: $small-font-size;
+}

--- a/backend/sass/index.scss
+++ b/backend/sass/index.scss
@@ -64,3 +64,4 @@
 @import 'common.blocks/signal';
 @import 'common.blocks/transaction-status';
 @import 'common.blocks/wallet';
+@import 'common.blocks/resources.scss';

--- a/frontend/src/Frontend/ReplGhcjs.hs
+++ b/frontend/src/Frontend/ReplGhcjs.hs
@@ -109,8 +109,11 @@ app sidebarExtra appCfg = void . mfix $ \ cfg -> do
           envCfg <- rightTabBar "main__right-pane" ideL
           pure $ uiEditorCfg <> envCfg
         pure $ controlCfg <> mainCfg
-      -- TODO resources page
-      FrontendRoute_Resources -> text "Resources" >> pure mempty
+      FrontendRoute_Resources -> mkPageContent "resources" $ do
+        controlBar "Resources" blank
+        elClass "main" "main page__main" $ do
+          resourcesWidget
+        pure mempty
       -- TODO settings page
       FrontendRoute_Settings -> text "Settings" >> pure mempty
     flattenedCfg <- flatten =<< tagOnPostBuild routedCfg
@@ -348,3 +351,23 @@ headerBtnCfg
   :: (Default (UiButtonCfgRep f), IsString (ReflexValue f CssClass), Semigroup (ReflexValue f CssClass))
   => UiButtonCfgRep f
 headerBtnCfg = btnCfgPrimary & uiButtonCfg_class %~ (<> "main-header__button")
+
+resourcesWidget
+  :: (DomBuilder t m)
+  => m ()
+resourcesWidget = elClass "div" "resources" $ do
+  resourceCell "Support" (static @"img/resources/support.svg") "#"
+    "Explore Help Resources to learn about Chainweaver, solve problems and get in touch"
+  resourceCell "Documentation" (static @"img/resources/documentation.svg") "http://pact-language.readthedocs.io/"
+    "Complete technical resources for Chainweaver, Kadena blockchain and Pact language"
+  resourceCell "Tutorials" (static @"img/resources/tutorials.svg") "https://pactlang.org/"
+    "Read or watch tutorials for writing smart contracts using the Pact language"
+  where
+    resourceCell title iconUrl href desc =
+      elAttr "a" ("class" =: "resources__cell" <> "href" =: href <> "target" =: "_blank")  $ do
+        elAttr "div" ("class" =: "resources__cell-icon" <> "style" =: ("background-image: url(" <> iconUrl <>")")) $ blank
+        elClass "div" "resources__cell-header" $ do
+          elAttr "img" ("src" =: (static @"img/launch.svg") <> "class" =: "resources__cell-launch") blank
+          elClass "span" "resources__cell-title" $ text title
+        elClass "div" "resources__cell-desc" $ text desc
+


### PR DESCRIPTION
The asana ticket just had a screenshot, so I'm not entirely certain what these buttons need to be linking to. But now that I've done the CSS dance it should be easy to get the links right from this, so just lmk what they should be. 

In the user story:

![Resources](https://user-images.githubusercontent.com/159197/68863187-9951e480-073a-11ea-9cac-7c689be6d444.png)

My UI:
![2019-11-14_23-55](https://user-images.githubusercontent.com/159197/68863218-a7a00080-073a-11ea-96ce-277768678f81.png)

Which is not pixel perfect the same yet, but given that the user story didn't have a launch icon on the documentation, I'm probably missing something important and don't want to make things pixel perfect till I have all the links clear in my head. 

I went ahead and assumed that we wanted the whole grid clickable rather than just the box. It does mean that you can click anywhere in a big poorly visually distinguished squares which is a little weird. Can make two separate hrefs for the icon and title box if that's weird: because someone for sure is going to click the icon. :slightly_smiling_face: 