### PR TITLE
fix: Adds in appropriate spacing post `text " "` removal

### DIFF
--- a/backend/sass/common.blocks/_modal.scss
+++ b/backend/sass/common.blocks/_modal.scss
@@ -137,8 +137,12 @@
   margin-right: $small-margin;
 }
 
-.modal__foter > *:last-child {
-  margin-left: 0;
+.modal__footer > .button {
+  margin-right: $normal-margin;
+}
+
+.modal__footer > *:last-child {
+  margin-right: 0;
 }
 
 .detail {

--- a/frontend/src/Frontend/UI/Dialogs/CallFunction.hs
+++ b/frontend/src/Frontend/UI/Dialogs/CallFunction.hs
@@ -184,6 +184,7 @@ argDelimiter = uiCodeFont "code-font_type_arg-delimiter" mempty
 renderArg :: MonadWidget t m => Arg (Term Name) -> m ()
 renderArg a = do
   uiCodeFont "code-font_type_pact-arg-name" $ (_aName a)
+  argDelimiter
   uiCodeFont "code-font_type_pact-type" $ prettyTextCompact (_aType a)
 
 

--- a/frontend/src/Frontend/UI/Dialogs/LogoutConfirmation.hs
+++ b/frontend/src/Frontend/UI/Dialogs/LogoutConfirmation.hs
@@ -14,6 +14,7 @@
 {-# LANGUAGE StandaloneDeriving    #-}
 {-# LANGUAGE TemplateHaskell       #-}
 {-# LANGUAGE TupleSections         #-}
+{-# LANGUAGE TypeApplications      #-}
 
 -- | Confirmation dialog for creating a GIST allowing setting of name and description.
 -- Copyright   :  (C) 2018 Kadena
@@ -64,12 +65,12 @@ uiLogoutConfirmation _onClose = do
           text "If you want to switch to a different GitHub account, you will also have to "
           elAttr "a" ("href" =: "https://github.com/logout" <> "target" =: "_blank") $
             text "logout"
+          text " "
           el "em" $ text "yourself"
           text " from GitHub."
 
   modalFooter $ do
     onCancel <- cancelButton def "Cancel"
-    text " "
     onConfirm <- confirmButton def "Logout"
     let
       cfg = mempty & oAuthCfg_logout .~ (OAuthProvider_GitHub <$ onConfirm)


### PR DESCRIPTION
I've added one `text " "` back that actually makes sense since it is a space in an actual paragraph of text (the github logout blurb). And removed a text " " that was still in the code spacing some buttons.

Mostly was just a css fix for spacing buttons nicely on a modal footer.