### PR TITLE
fix: Better focus handling for passphrase input

### DIFF
--- a/backend/sass/common.blocks/_setup.scss
+++ b/backend/sass/common.blocks/_setup.scss
@@ -275,25 +275,12 @@ $kadena-orange: #F3AB3C;
   opacity: 0;
 }
 
-.setup__passphrase-widget-elem-wrapper {
-  &:focus-within {
-    .setup__passphrase-widget-word {
-      opacity: 1 !important;
-    }
+.setup__passphrase-widget-word--focused {
+  opacity: 1;
+}
 
-    .setup__passphrase-widget-word-hider {
-      display: none !important;
-    }
-  }
-  &:hover {
-    .setup__passphrase-widget-word {
-      opacity: 1;
-    }
-
-    .setup__passphrase-widget-word-hider {
-      display: none;
-    }
-  }
+.setup__passphrase-widget-word-hider--focused {
+  display: none;
 }
 
 .setup__fullscreen .setup__verify-phrase-msg {

--- a/desktop/src/Desktop/Setup.hs
+++ b/desktop/src/Desktop/Setup.hs
@@ -17,6 +17,7 @@ import Control.Monad (unless,void)
 import Control.Monad.Fix (MonadFix)
 import Control.Monad.IO.Class
 import Data.Bool (bool)
+import Data.Foldable (fold)
 import Data.Maybe (isNothing, fromMaybe)
 import Data.Bifunctor
 import Data.ByteArray (ByteArrayAccess)
@@ -284,31 +285,45 @@ recoverWallet eBack = Workflow $ do
     )
 
 passphraseWordElement
-  :: (DomBuilder t m, PostBuild t m)
+  :: (DomBuilder t m, PostBuild t m, MonadFix m, MonadHold t m)
   => Dynamic t PassphraseStage
   -> WordKey
   -> Dynamic t Text
   -> m (Event t Text)
-passphraseWordElement currentStage k wrd = setupDiv "passphrase-widget-elem-wrapper" $ do
-  pb <- getPostBuild
+passphraseWordElement currentStage k wrd = mdo
+  let eFocused = leftmost
+        [ eInputFocused
+        , True <$ domEvent Mouseenter elt
+        , False <$ domEvent Mouseleave elt
+        ]
+  (elt, (eInputFocused, eInput)) <- elClass' "div" (setupClass "passphrase-widget-elem-wrapper") $ mdo
+    pb <- getPostBuild
 
-  setupDiv "passphrase-widget-key-wrapper" $
-    text (showWordKey k)
+    setupDiv "passphrase-widget-key-wrapper" $
+      text (showWordKey k)
 
-  let
-    commonAttrs cls =
-      "type" =: "text" <>
-      "size" =: "8" <>
-      "class" =: setupClass cls
+    let
+      commonClass cls focused = "input " <> (setupClass cls <> bool "" (" " <> setupClass cls <> "--focused")  focused)
+      commonAttrs cls focused =
+        "type" =: "text" <>
+        "size" =: "8" <>
+        "class" =: commonClass cls focused
 
-  void . uiInputElement $ def
-    & inputElementConfig_initialValue .~ "********"
-    & initialAttributes .~ (commonAttrs "passphrase-widget-word-hider" <> "disabled" =: "true" <> "tabindex" =: "-1")
+    hiderElt <- uiInputElement $ def
+      & inputElementConfig_initialValue .~ "********"
+      & initialAttributes .~ (commonAttrs "passphrase-widget-word-hider" False <> "disabled" =: "true" <> "tabindex" =: "-1")
+      & modifyAttributes <>~ (("class" =:) . Just . commonClass "passphrase-widget-word-hider" <$> eFocused)
 
-  fmap _inputElement_input $ setupDiv "passphrase-widget-word-wrapper". uiInputElement $ def
-    & inputElementConfig_setValue .~ (current wrd <@ pb)
-    & initialAttributes .~ commonAttrs "passphrase-widget-word"
-    & modifyAttributes <>~ (("readonly" =:) . canEditOnRecover <$> current currentStage <@ pb)
+    inputElt <- setupDiv "passphrase-widget-word-wrapper". uiInputElement $ def
+      & inputElementConfig_setValue .~ (current wrd <@ pb)
+      & initialAttributes .~ commonAttrs "passphrase-widget-word" False
+      & modifyAttributes <>~ fold
+        [ (("readonly" =:) . canEditOnRecover <$> current currentStage <@ pb)
+        , (("class" =:) . Just . commonClass "passphrase-widget-word" <$> eFocused)
+        ]
+
+    pure (updated $ _inputElement_hasFocus inputElt, _inputElement_input inputElt)
+  pure eInput
   where
     canEditOnRecover Recover = Nothing
     canEditOnRecover Setup = Just "true"


### PR DESCRIPTION
Instead of using hover and focus psuedoselectors, this maintains
a Event t Bool for whether the word is focused or not. This is
triggered either by a mouseenter, mouseexit, mousemove or the for element
being tabbed into/out from.

Prior to this, with the psuedoselector the first entry stayed visible
because the user would normally click on that first one to focus and
even once you tab out the mouse is still hovering the element, so it
stays visible.

The best possible fix is to also have an event for when any other word
has been focused to explicitly blur everything else, but that's probably
too fancy and asking for causality loops. :)