### PR TITLE
fix: Changes form to handle onSubmit

### DIFF
--- a/desktop/src/Desktop/Setup.hs
+++ b/desktop/src/Desktop/Setup.hs
@@ -574,9 +574,9 @@ setPassword dSeed = do
     dynText $ fromMaybe T.empty <$> lastError
 
   pure $ leftmost
-      [ Nothing <$ err
-      , (\s -> Just . Crypto.generate s) <$> current dSeed <@> (T.encodeUtf8 <$> pass)
-      ]
+    [ Nothing <$ err
+    , (\s -> Just . Crypto.generate s) <$> current dSeed <@> (T.encodeUtf8 <$> pass)
+    ]
 
   where
     minPasswordLength = 10

--- a/desktop/src/Desktop/Setup.hs
+++ b/desktop/src/Desktop/Setup.hs
@@ -10,13 +10,14 @@
 -- | Wallet setup screens
 module Desktop.Setup (runSetup, form, kadenaWalletLogo, setupDiv, setupClass) where
 
-import Control.Lens ((<>~))
+import Control.Lens ((<>~), (%~))
 import Control.Error (hush)
 import Control.Applicative (liftA2)
 import Control.Monad (unless,void)
 import Control.Monad.Fix (MonadFix)
 import Control.Monad.IO.Class
 import Data.Bool (bool)
+import Data.Proxy (Proxy(Proxy))
 import Data.Foldable (fold)
 import Data.Maybe (isNothing, fromMaybe)
 import Data.Bifunctor
@@ -102,9 +103,17 @@ textTo = fromString . T.unpack
 tshow :: Show a => a -> Text
 tshow = T.pack . show
 
--- | Form wrapper which will automatically handle submit on enter
-form :: DomBuilder t m => Text -> m a -> m a
-form c = elAttr "form" ("onsubmit" =: "return false;" <> "class" =: c)
+-- | Form wrapper which will automatically handle submit on enter so long as you have
+-- a submit button in the form. Please track this submit event instead of a button click
+-- as it is very easy to put the button outside of the form and break enter handling.
+-- This way, both will work or both will be broken (if there is no button in the form)
+form :: forall t m a. DomBuilder t m => Text -> m a -> m (Event t (), a)
+form c w = do
+  let cfg = (def :: ElementConfig EventResult t (DomBuilderSpace m))
+        & elementConfig_eventSpec %~ addEventSpecFlags (Proxy :: Proxy (DomBuilderSpace m)) Submit (\_ -> preventDefault)
+        & elementConfig_initialAttributes .~ ("class" =: c)
+  (elt, a) <- element "form" cfg w
+  pure (domEvent Submit elt, a)
 
 -- | Wallet logo
 kadenaWalletLogo :: DomBuilder t m => m ()
@@ -271,10 +280,14 @@ recoverWallet eBack = Workflow $ do
         pure never
 
       withSeedConfirmPassword seed = setupDiv "recover-enter-password" $ do
-        dSetPw <- holdDyn Nothing =<< setPassword (pure seed)
-        continue <- setupDiv "recover-restore-button" $
-          confirmButton (def & uiButtonCfg_disabled .~ (fmap isNothing dSetPw)) "Restore"
-        pure $ tagMaybe (current dSetPw) continue
+        (ePwSubmit, dSetPw) <- form "" $ do
+          eSetPw <- setPassword (pure seed)
+          dSetPw' <- holdDyn Nothing eSetPw
+          -- Event handled by form onSubmit
+          void $ setupDiv "recover-restore-button" $
+            confirmButton (def & uiButtonCfg_disabled .~ (fmap isNothing dSetPw')) "Restore"
+          pure dSetPw'
+        pure $ tagMaybe (current dSetPw) ePwSubmit
 
   dSetPassword <- widgetHold waitingForPhrase $
     withSeedConfirmPassword <$> eSeedUpdated
@@ -368,9 +381,13 @@ createNewWallet eBack = Workflow $  do
 
     proceed :: Crypto.MnemonicSentence 12 -> m (Event t (SetupWF t m))
     proceed mnem = do
-      dPassword <- setPassword (pure $ sentenceToSeed mnem) >>= holdDyn Nothing
-      continue <- continueButton (fmap isNothing dPassword)
-      pure $ precreatePassphraseWarning eBack dPassword mnem <$ continue
+      (ePwSubmit, dPassword) <- form "" $ do
+        eSetPw' <- setPassword (pure $ sentenceToSeed mnem)
+        dPassword' <- holdDyn Nothing eSetPw'
+        -- Event handled by form onSubmit
+        void $ continueButton (fmap isNothing dPassword')
+        pure dPassword'
+      pure $ precreatePassphraseWarning eBack dPassword mnem <$ ePwSubmit
 
   dContinue <- widgetHold generating (proceed <$> eGenSuccess)
 
@@ -525,7 +542,7 @@ setPassword
   :: (DomBuilder t m, MonadHold t m, MonadFix m, PerformEvent t m, PostBuild t m, MonadJSM (Performable m), TriggerEvent t m)
   => Dynamic t Crypto.Seed
   -> m (Event t (Maybe Crypto.XPrv))
-setPassword dSeed = form "" $ do
+setPassword dSeed = do
   let uiPassword' = uiPassword (setupClass "password-wrapper") (setupClass "password")
 
   p1elem <- uiPassword' $ "Enter password (" <> tshow minPasswordLength <> " character min.)"
@@ -557,9 +574,9 @@ setPassword dSeed = form "" $ do
     dynText $ fromMaybe T.empty <$> lastError
 
   pure $ leftmost
-    [ Nothing <$ err
-    , (\s -> Just . Crypto.generate s) <$> current dSeed <@> (T.encodeUtf8 <$> pass)
-    ]
+      [ Nothing <$ err
+      , (\s -> Just . Crypto.generate s) <$> current dSeed <@> (T.encodeUtf8 <$> pass)
+      ]
 
   where
     minPasswordLength = 10


### PR DESCRIPTION
This is better than attaching to the button, because if you forget to put the button inside the form element, enter handling breaks.

Forcing folk towards handling onSubmit means that either both will be broken or both will work, which is nice and is probably better than one being broken and having to get picked up in QA.