### PR TITLE
fix: Centers the wallet image on the AddAccount success screen

### DIFF
--- a/backend/sass/common.blocks/_modal.scss
+++ b/backend/sass/common.blocks/_modal.scss
@@ -216,7 +216,6 @@
 }
 
 .wallet_only__account-created-done-splash-bg {
-  background: url(static/img/Wallet_Graphic_1.png);
   background-size: cover;
   transform: rotateY(180deg);
   margin: 0 auto;

--- a/backend/sass/common.blocks/_modal.scss
+++ b/backend/sass/common.blocks/_modal.scss
@@ -216,16 +216,18 @@
 }
 
 .wallet_only__account-created-done-splash-bg {
+  background: url(static/img/Wallet_Graphic_1.png);
+  background-size: cover;
   transform: rotateY(180deg);
-  margin-left: 22rem;
+  margin: 0 auto;
   width: 180px;
   height: 125px;
 }
 
 .wallet_only__account-created-wallet-blue-icon {
-  position: absolute;
-  top: 8rem;
-  left: 28rem;
+  transform: rotateY(180deg);
+  position: relative;
+  top: 20px;
   width: 76px;
   height: 72px;
 }

--- a/frontend/src/Frontend/UI/Dialogs/AddAccount.hs
+++ b/frontend/src/Frontend/UI/Dialogs/AddAccount.hs
@@ -131,15 +131,11 @@ uiWalletOnlyAccountCreated
 uiWalletOnlyAccountCreated newConf onClose newAccount = Workflow $ do
   _ <- modalMain $ divClass "segment modal__main wallet_only__account-created-modal" $ do
     elClass "h2" "heading heading_type_h2" $ do
-      elAttr "img" (
-        "src" =: static @"img/Wallet_Graphic_1.png" <>
-        "class" =: "wallet_only__account-created-splash-bg wallet_only__account-created-done-splash-bg"
-        ) blank
-
-      elAttr "img" (
-        "src" =: static @"img/Wallet_Icon_Highlighted_Blue.png" <>
-        "class" =: "wallet_only__account-created-wallet-blue-icon"
-        ) blank
+      elAttr "div" ("class" =: "wallet_only__account-created-done-splash-bg") $
+        elAttr "img" (
+          "src" =: static @"img/Wallet_Icon_Highlighted_Blue.png" <>
+          "class" =: "wallet_only__account-created-wallet-blue-icon"
+          ) blank
 
     divClass "wallet-only__account-created-details" $ do
       divClass "wallet-only__account-heading" $ text "Account Created:"

--- a/frontend/src/Frontend/UI/Dialogs/AddAccount.hs
+++ b/frontend/src/Frontend/UI/Dialogs/AddAccount.hs
@@ -131,7 +131,10 @@ uiWalletOnlyAccountCreated
 uiWalletOnlyAccountCreated newConf onClose newAccount = Workflow $ do
   _ <- modalMain $ divClass "segment modal__main wallet_only__account-created-modal" $ do
     elClass "h2" "heading heading_type_h2" $ do
-      elAttr "div" ("class" =: "wallet_only__account-created-done-splash-bg") $
+      elAttr "div"
+        (  "class" =: "wallet_only__account-created-done-splash-bg"
+        <> "style" =: ("background-image: url(" <> (static @"img/Wallet_Graphic_1.png") <> ")")
+        ) $
         elAttr "img" (
           "src" =: static @"img/Wallet_Icon_Highlighted_Blue.png" <>
           "class" =: "wallet_only__account-created-wallet-blue-icon"


### PR DESCRIPTION
Prior to this we had two images and absolutely positioning one over the other.
This meant moving the base meant twiddling pixels with the other. This now just
uses a block with a background that should be much more robust. The only thing
to be careful of here is the relationship between the height of the div and the
vertical positioning of the inner image, which is still better than before. :)