### PR TITLE
feat: Shows a message when precision input gets trimmed

### DIFF
--- a/backend/sass/common.blocks/_input.scss
+++ b/backend/sass/common.blocks/_input.scss
@@ -143,3 +143,9 @@ input[type=number] {
   padding-left: 10px;
   color: $tertiary-color;
 }
+
+.real-input__rounded {
+  position: absolute;
+  right: 10px;
+  color: $tertiary-color;
+}


### PR DESCRIPTION
It doesn't look terrible (just fits on the smallest dialog size), but feedback welcome on the text.

![smallest dialog](https://user-images.githubusercontent.com/159197/69241063-a878dc80-0be9-11ea-886c-b0b6c14e23ee.png)
![biggest dialog](https://user-images.githubusercontent.com/159197/69241064-a9117300-0be9-11ea-9fc5-9a1fded06009.png)
