### PR TITLE
fix: Properly aligns spinner

### DIFF
--- a/backend/sass/common.blocks/_spinner.scss
+++ b/backend/sass/common.blocks/_spinner.scss
@@ -8,6 +8,10 @@
 @import '../include/defs';
 
 .spinner {
+  width: 100%;
+}
+
+.spinner__cubes {
   margin: 100px auto;
   width: 60px;
   height: 40px;
@@ -17,6 +21,7 @@
 .spinner__msg {
     position: relative;
     margin: -60px auto;
+    width: 60px;
 }
 
 .cube1, .cube2 {

--- a/frontend/src/Frontend.hs
+++ b/frontend/src/Frontend.hs
@@ -68,6 +68,7 @@ frontend = Frontend
       }
   }
 
+
 -- | The 'JSM' action *must* be run from a user initiated event in order for the
 -- dialog to open
 openFileDialog :: MonadWidget t m => m (Event t Text, JSM ())
@@ -87,8 +88,8 @@ openFileDialog = do
   pure (fmapMaybe id mContents, open)
 
 loaderMarkup :: DomBuilder t m => m ()
-loaderMarkup = do
-  divClass "spinner" $ do
+loaderMarkup = divClass "spinner" $ do
+  divClass "spinner__cubes" $ do
     divClass "cube1" blank
     divClass "cube2" blank
   divClass "spinner__msg" $ text "Loading"


### PR DESCRIPTION
The change of the body flex direction to row instead of column in https://github.com/kadena-io/chainweaver/commit/bb0697dc23a9abe844ab357be298973de2f4da0c broke
the old spinner. This puts a full sized non-flex div there for the old positioning to work with instead.