### PR TITLE
fix: word-break: break-all on raw transaction output

### DIFF
--- a/backend/sass/common.blocks/_modal.scss
+++ b/backend/sass/common.blocks/_modal.scss
@@ -185,6 +185,10 @@
   }
 }
 
+.transaction_details__raw-response {
+  word-break: break-all;
+}
+
 .account-details__copy-btn-wrapper {
   text-align: right;
 

--- a/frontend/src/Frontend/UI/Dialogs/DeployConfirmation.hs
+++ b/frontend/src/Frontend/UI/Dialogs/DeployConfirmation.hs
@@ -259,7 +259,7 @@ fullDeployFlowWithSubmit dcfg model onPreviewConfirm runner _onClose = do
               el "td" $ dynText $ displayBalance <$> balance
 
         divClass "title" $ text "Raw Response"
-        _ <- divClass "group segment" $ runWithReplace (text "Loading...") $ leftmost
+        _ <- divClass "group segment transaction_details__raw-response" $ runWithReplace (text "Loading...") $ leftmost
           [ text . renderCompactText . snd <$> resp
           , text <$> errors
           ]


### PR DESCRIPTION
On a really long string like an account key in the raw output wasn't word
breaking and pushing the dialog out of whack. Break always when the max width
is reached regardless of word boundaries.