### PR TITLE
Fix: Expands the width of the actions column

### DIFF
--- a/frontend/src/Frontend/UI/Wallet.hs
+++ b/frontend/src/Frontend/UI/Wallet.hs
@@ -135,8 +135,8 @@ uiKeyItems model = do
       elAttr "col" ("style" =: "width: 19%") blank
       elAttr "col" ("style" =: "width: 10%") blank
       elAttr "col" ("style" =: "width: 19%") blank
-      elAttr "col" ("style" =: "width: 16%") blank
-      elAttr "col" ("style" =: "width: 19%") blank
+      elAttr "col" ("style" =: "width: 15%") blank
+      elAttr "col" ("style" =: "width: 20%") blank
     el "thead" $ el "tr" $ do
       let mkHeading = elClass "th" "wallet__table-heading" . text
       traverse_ mkHeading $


### PR DESCRIPTION
Without this with a browser at 1400 px wide the button texts are cut off. Really should always make sure I'm devving with a 1400px wide window. lol. 