### PR TITLE
Kadena Address Changes

### DIFF
--- a/deps/crc/default.nix
+++ b/deps/crc/default.nix
@@ -1,0 +1,7 @@
+# DO NOT HAND-EDIT THIS FILE
+import ((import <nixpkgs> {}).fetchFromGitHub (
+  let json = builtins.fromJSON (builtins.readFile ./github.json);
+  in { inherit (json) owner repo rev sha256;
+       private = json.private or false;
+     }
+))

--- a/deps/crc/github.json
+++ b/deps/crc/github.json
@@ -1,0 +1,7 @@
+{
+  "owner": "MichaelXavier",
+  "repo": "crc",
+  "branch": "master",
+  "rev": "a20496716eeefc11c21617c101810451f5d7b75e",
+  "sha256": "144zh6735l91631dvm2gaprsid22hfvrasr77krx5qzfqfyibd09"
+}

--- a/frontend/frontend.cabal
+++ b/frontend/frontend.cabal
@@ -79,7 +79,7 @@ library
                , unordered-containers
                , kadena-signing-api
                , base64-bytestring
-               , uri-bytestring
+               , crc
                , attoparsec
                , vector
 

--- a/frontend/frontend.cabal
+++ b/frontend/frontend.cabal
@@ -38,7 +38,6 @@ library
                , free
                , generic-deriving
                , ghcjs-dom
-               , hashing
                , http-client
                , http-client-tls
                , http-types

--- a/frontend/src/Frontend/KadenaAddress.hs
+++ b/frontend/src/Frontend/KadenaAddress.hs
@@ -70,21 +70,19 @@ The address will contain the following fields:
 AccountName: Compliant with the requirements contained in pact. In the case of wallet-only
 accounts that do not exist on the blockchain, the Public Key will be used.
 ChainId: Non-negative integer.
-Network: The network where the chain resides.
-Checksum: The checksum will be SHA256 of the 'AccountName/PublicKey', 'ChainId',
-‘Network’. An invalid checksum will be a parse failure.
+Checksum: The checksum will be CRC32 of the 'Created Status', 'AccountName/PublicKey', 'ChainId'.
+An invalid checksum will be a parse failure.
 
 Some examples of the encoding (delimiter yet to be determined):
 
 Using newlines:
+y
 doug
 1
-us1.tn1.chainweb.com
-1bfafb513a26979b48bafe3f9c0fba7703065066a84421f71ca41b54692de67d
 71f920fa275127a7b60fa4d4d41432a3
 
 Or some other delimiter:
-doug%1%us1.tn1.chainweb.com%1bfafb513a26979b48bafe3f9c0fba7703065066a84421f71ca41b54692de67d%71f920fa275127a7b60fa4d4d41432a3
+doug|1|71f920fa275127a7b60fa4d4d41432a3
 
 The final form includes a human readable component as well as machine readable components:
 

--- a/frontend/src/Frontend/KadenaAddress.hs
+++ b/frontend/src/Frontend/KadenaAddress.hs
@@ -186,9 +186,12 @@ encodeKadenaAddress ka =
       , checksum
       ]
   in
-    case _kadenaAddress_accountCreated ka of
-      AccountCreated_Yes -> name <> cons humanReadableDelimiter cid <> cons humanReadableDelimiter encoded
-      AccountCreated_No -> name <> cons humanReadableDelimiter cid <> cons humanReadableDelimiter checksum
+    name
+    <> cons humanReadableDelimiter cid
+    <> cons humanReadableDelimiter (case _kadenaAddress_accountCreated ka of
+                                      AccountCreated_Yes -> encoded
+                                      AccountCreated_No -> checksum
+                                   )
 
 mkKadenaAddress
   :: AccountCreated

--- a/frontend/src/Frontend/KadenaAddress.hs
+++ b/frontend/src/Frontend/KadenaAddress.hs
@@ -186,12 +186,13 @@ encodeKadenaAddress ka =
       , checksum
       ]
   in
-    name
-    <> cons humanReadableDelimiter cid
-    <> cons humanReadableDelimiter (case _kadenaAddress_accountCreated ka of
-                                      AccountCreated_Yes -> encoded
-                                      AccountCreated_No -> checksum
-                                   )
+    mconcat $ intersperse (BS.singleton humanReadableDelimiter)
+    [ name
+    , cid
+    , case _kadenaAddress_accountCreated ka of
+        AccountCreated_Yes -> encoded
+        AccountCreated_No -> checksum
+    ]
 
 mkKadenaAddress
   :: AccountCreated

--- a/frontend/src/Frontend/Wallet.hs
+++ b/frontend/src/Frontend/Wallet.hs
@@ -126,7 +126,11 @@ instance FromJSON key => FromJSON (Account key) where
   parseJSON = genericParseJSON defaultOptions
 
 accountToKadenaAddress :: Account key -> KadenaAddress
-accountToKadenaAddress a = mkKadenaAddress (_account_network a) (_account_chainId a) (_account_name a)
+accountToKadenaAddress a = mkKadenaAddress addPrefix KadenaAddress_AccountCreated_No (_account_chainId a) (_account_name a)
+  where
+    addPrefix = if unAccountName (_account_name a) == keyToText (_keyPair_publicKey $ _account_key a)
+      then KadenaAddressPrefix_None
+      else KadenaAddressPrefix_Keep
 
 data WalletCfg key t = WalletCfg
   { _walletCfg_genKey     :: Event t (AccountName, NetworkName, ChainId, Text)

--- a/frontend/src/Frontend/Wallet.hs
+++ b/frontend/src/Frontend/Wallet.hs
@@ -126,11 +126,11 @@ instance FromJSON key => FromJSON (Account key) where
   parseJSON = genericParseJSON defaultOptions
 
 accountToKadenaAddress :: Account key -> KadenaAddress
-accountToKadenaAddress a = mkKadenaAddress addPrefix KadenaAddress_AccountCreated_No (_account_chainId a) (_account_name a)
+accountToKadenaAddress a = mkKadenaAddress isCreated (_account_chainId a) (_account_name a)
   where
-    addPrefix = if unAccountName (_account_name a) == keyToText (_keyPair_publicKey $ _account_key a)
-      then KadenaAddressPrefix_None
-      else KadenaAddressPrefix_Keep
+    isCreated = if unAccountName (_account_name a) == keyToText (_keyPair_publicKey $ _account_key a)
+      then AccountCreated_No -- Wallet only account
+      else AccountCreated_Yes -- Vanity account
 
 data WalletCfg key t = WalletCfg
   { _walletCfg_genKey     :: Event t (AccountName, NetworkName, ChainId, Text)

--- a/frontend/tests/KadenaAddressSpec.hs
+++ b/frontend/tests/KadenaAddressSpec.hs
@@ -14,19 +14,22 @@ import Kadena.SigningApi (mkAccountName)
 import Common.Network (ChainId (..))
 import qualified Frontend.KadenaAddress as KA
 
-prop_parse_kadenaAddress_roundtrip :: Property
-prop_parse_kadenaAddress_roundtrip = property $ do
-  ka <- forAll $ KA.mkKadenaAddress KA.KadenaAddressPrefix_Keep KA.KadenaAddress_AccountCreated_No <$> genChainId <*> genAccountName
-
+prop_parse_kadenaAddress_roundtrip_Created_Yes :: Property
+prop_parse_kadenaAddress_roundtrip_Created_Yes = property $ do
+  ka <- forAll $ KA.mkKadenaAddress <$> genCreated <*> genChainId <*> genAccountName
   tripping ka KA.encodeKadenaAddress KA.decodeKadenaAddress
   where
+    genCreated = Gen.element [KA.AccountCreated_Yes, KA.AccountCreated_No]
     genAccountName = Gen.just $ hush . mkAccountName <$> Gen.text (Range.linear 3 256) printableLatin1
     genChainId = ChainId . T.singleton <$> Gen.digit
 
     printableLatin1 = Gen.filterT isPrintable Gen.latin1
 
-    isPrintable char =
-      not (C.isSpace char || C.isControl char || C.ord char == fromIntegral KA.humanReadableDelimiter)
+    isPrintable char = not
+      ( C.isSpace char ||
+        C.isControl char ||
+        C.ord char == fromIntegral KA.humanReadableDelimiter
+      )
 
 main :: IO Bool
 main = checkParallel $$(discover)

--- a/frontend/tests/KadenaAddressSpec.hs
+++ b/frontend/tests/KadenaAddressSpec.hs
@@ -18,7 +18,7 @@ prop_parse_kadenaAddress_roundtrip :: Property
 prop_parse_kadenaAddress_roundtrip = property $ do
   ka <- forAll $ KA.mkKadenaAddress KA.KadenaAddressPrefix_Keep KA.KadenaAddress_AccountCreated_No <$> genChainId <*> genAccountName
 
-  tripping ka KA._kadenaAddress_encoded KA.decodeKadenaAddress
+  tripping ka KA.encodeKadenaAddress KA.decodeKadenaAddress
   where
     genAccountName = Gen.just $ hush . mkAccountName <$> Gen.text (Range.linear 3 256) printableLatin1
     genChainId = ChainId . T.singleton <$> Gen.digit

--- a/frontend/tests/KadenaAddressSpec.hs
+++ b/frontend/tests/KadenaAddressSpec.hs
@@ -11,22 +11,22 @@ import qualified Data.Text as T
 import qualified Data.Char as C
 import Kadena.SigningApi (mkAccountName)
 
-import Common.Network (ChainId (..), uncheckedNetworkName)
+import Common.Network (ChainId (..))
 import qualified Frontend.KadenaAddress as KA
 
 prop_parse_kadenaAddress_roundtrip :: Property
 prop_parse_kadenaAddress_roundtrip = property $ do
-  ka <- forAll $ KA.mkKadenaAddress <$>  genNetworkName <*> genChainId <*> genAccountName
+  ka <- forAll $ KA.mkKadenaAddress KA.KadenaAddressPrefix_Keep KA.KadenaAddress_AccountCreated_No <$> genChainId <*> genAccountName
+
   tripping ka KA._kadenaAddress_encoded KA.decodeKadenaAddress
   where
     genAccountName = Gen.just $ hush . mkAccountName <$> Gen.text (Range.linear 3 256) printableLatin1
-    genNetworkName = Gen.constant (uncheckedNetworkName "us1.tn1.chainweb.com") -- I don't want to write URL generator just yet
     genChainId = ChainId . T.singleton <$> Gen.digit
 
     printableLatin1 = Gen.filterT isPrintable Gen.latin1
 
     isPrintable char =
-      not (C.isSpace char || C.isControl char || char == ']')
+      not (C.isSpace char || C.isControl char || C.ord char == fromIntegral KA.humanReadableDelimiter)
 
 main :: IO Bool
 main = checkParallel $$(discover)

--- a/obApp.nix
+++ b/obApp.nix
@@ -41,6 +41,7 @@ in
           obelisk-oauth-backend = hackGet ./deps/obelisk-oauth + /backend;
           # Needed for obelisk-oauth currently (ghcjs support mostly):
           entropy = hackGet ./deps/entropy;
+          crc = hackGet ./deps/crc;
           cardano-crypto = hackGet ./deps/cardano-crypto;
           kadena-signing-api = hackGet ./deps/signing-api + /kadena-signing-api;
           desktop = ./desktop;


### PR DESCRIPTION
Change the checksum to pure haskell CRC32 using `crc` package.

- Remove network name from the address.
- Add a flag to indicate if the account has been created yet, defaults to no.
- Remove `uri-bytestring` dependency.
- Update test.