### PR TITLE
Fix potential issue in address decoding.

### DIFF
--- a/frontend/frontend.cabal
+++ b/frontend/frontend.cabal
@@ -203,6 +203,9 @@ test-suite kadenaaddress
                , frontend
                , hedgehog
                , kadena-signing-api
+               , pact
                , errors
                , text
                , common
+               , lens
+               , bytestring

--- a/frontend/tests/KadenaAddressSpec.hs
+++ b/frontend/tests/KadenaAddressSpec.hs
@@ -6,30 +6,55 @@ import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Internal.Gen as Gen
 import qualified Hedgehog.Range as Range
 
-import Control.Error (hush)
+import Control.Monad (when)
+import Control.Lens ((^.))
+import Control.Error (hush,isRight,isLeft)
+import Data.Bifunctor (first)
 import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
 import qualified Data.Char as C
-import Kadena.SigningApi (mkAccountName)
+import qualified Data.ByteString.Char8 as BS8
 
+import Kadena.SigningApi (mkAccountName,unAccountName)
+
+import Pact.Types.ChainId (chainId)
 import Common.Network (ChainId (..))
 import qualified Frontend.KadenaAddress as KA
 
-prop_parse_kadenaAddress_roundtrip_Created_Yes :: Property
-prop_parse_kadenaAddress_roundtrip_Created_Yes = property $ do
-  ka <- forAll $ KA.mkKadenaAddress <$> genCreated <*> genChainId <*> genAccountName
-  tripping ka KA.encodeKadenaAddress KA.decodeKadenaAddress
+printableLatin1 = Gen.filterT isPrintable Gen.latin1
   where
-    genCreated = Gen.element [KA.AccountCreated_Yes, KA.AccountCreated_No]
-    genAccountName = Gen.just $ hush . mkAccountName <$> Gen.text (Range.linear 3 256) printableLatin1
-    genChainId = ChainId . T.singleton <$> Gen.digit
-
-    printableLatin1 = Gen.filterT isPrintable Gen.latin1
-
     isPrintable char = not
       ( C.isSpace char ||
         C.isControl char ||
         C.ord char == fromIntegral KA.humanReadableDelimiter
       )
+
+genKadenaAddress :: Gen KA.KadenaAddress
+genKadenaAddress = KA.mkKadenaAddress <$> genCreated <*> genChainId <*> genAccountName
+  where
+    genCreated = Gen.element [KA.AccountCreated_Yes, KA.AccountCreated_No]
+    genAccountName = Gen.just $ hush . mkAccountName <$> Gen.text (Range.linear 3 256) printableLatin1
+    genChainId = ChainId . T.singleton <$> Gen.digit
+
+prop_parse_kadenaAddress_roundtrip_Created_Yes :: Property
+prop_parse_kadenaAddress_roundtrip_Created_Yes = property $ do
+  ka <- forAll genKadenaAddress
+  tripping ka KA.encodeKadenaAddress KA.decodeKadenaAddress
+
+prop_parse_kadenaAddress_encoding :: Property
+prop_parse_kadenaAddress_encoding = property $ do
+  ka <- forAll genKadenaAddress
+  let
+    isCreated = KA._kadenaAddress_accountCreated ka == KA.AccountCreated_Yes
+    encoded = KA.encodeKadenaAddress ka
+    [name, chain, chksumOrEncoding] = BS8.split (C.chr (fromIntegral KA.humanReadableDelimiter)) encoded
+
+  TE.decodeLatin1 name === unAccountName (KA._kadenaAddress_accountName ka)
+  TE.decodeLatin1 chain === (KA._kadenaAddress_chainId ka ^. chainId)
+
+  if isCreated
+    then KA.decodeKadenaAddress chksumOrEncoding === Right ka
+    else chksumOrEncoding === KA.bytestringChecksum (KA._kadenaAddress_checksum ka)
 
 main :: IO Bool
 main = checkParallel $$(discover)


### PR DESCRIPTION
Uncreated accounts could have potentially accepted invalid chainIds.

Updated tests to check that encoding matches structural expectations.