### PR TITLE
fix: Adds text-wrap to preview tab raw response.

### DIFF
--- a/frontend/src/Frontend/UI/DeploymentSettings.hs
+++ b/frontend/src/Frontend/UI/DeploymentSettings.hs
@@ -1001,7 +1001,7 @@ uiDeployPreview model settings accounts gasLimit ttl code lastPublicMeta capabil
             el "td" $ dynText $ displayBalance <$> balance
 
       divClass "title" $ text "Raw Response"
-      void $ divClass "group segment" $ runWithReplace (text "Loading...") $ leftmost
+      void $ divClass "group segment transaction_details__raw-response" $ runWithReplace (text "Loading...") $ leftmost
         [ text . renderCompactText . snd <$> resp
         , text <$> errors
         ]


### PR DESCRIPTION
When the preview tab was created in https://github.com/kadena-io/chainweaver/pull/236/files#diff-55712e3137bf1a0aefa5463d98924d80R1004
there was UI copied from DeployConfirmation. I fixed the UI in DeployConfirmation
but that UI got copied before the fix and I didn't pick this up in review, sorry!