### PR TITLE
Blk@redesign/capabilities ui

### DIFF
--- a/backend/sass/common.blocks/_modal.scss
+++ b/backend/sass/common.blocks/_modal.scss
@@ -262,3 +262,8 @@
 .grant-capabilities-static-input {
   padding: 0;
 }
+
+.signing-ui-signers__signer {
+  margin-top: $normal-margin;
+  margin-bottom: $normal-margin;
+}

--- a/backend/sass/common.blocks/_modal.scss
+++ b/backend/sass/common.blocks/_modal.scss
@@ -246,3 +246,19 @@
     margin-right: 10px;
   }
 }
+
+.grant-capabilities-title {
+  display: flex;
+  align-items: center;
+
+  .grant-capabilities-title__title {
+    flex-grow: 2;
+  }
+  .grant-capabilities-title__add-button {
+    margin-right: 1em;
+  }
+}
+
+.grant-capabilities-static-input {
+  padding: 0;
+}

--- a/backend/sass/common.blocks/_modal.scss
+++ b/backend/sass/common.blocks/_modal.scss
@@ -262,6 +262,10 @@
 .grant-capabilities-static-input {
   padding: 0;
 }
+.grant-capabilities-apply-all-wrapper {
+  display: flex;
+  justify-content: flex-end;
+}
 
 .signing-ui-signers__signer {
   margin-top: $normal-margin;

--- a/desktop/desktop.cabal
+++ b/desktop/desktop.cabal
@@ -52,4 +52,6 @@ library
     , Desktop.Mac
     , Desktop.Orphans
     , Desktop.Setup
+    , Desktop.SigningApi
+    , Desktop.Util
   ghc-options: -Wall

--- a/desktop/src/Desktop/Mac.hs
+++ b/desktop/src/Desktop/Mac.hs
@@ -8,9 +8,8 @@
 module Desktop.Mac where
 
 import Control.Concurrent
-import Control.Exception (bracket_, bracket, try)
+import Control.Exception (bracket, try)
 import Control.Monad (forever)
-import Control.Monad.Except (throwError)
 import Control.Monad.IO.Class
 import Data.Foldable (for_)
 import Data.String (IsString(..))
@@ -26,16 +25,12 @@ import System.FilePath ((</>))
 import System.IO
 import qualified Control.Concurrent.Async as Async
 import qualified Data.ByteString as BS
-import qualified Data.ByteString.Lazy as LBS
 import qualified Data.List as L
 import qualified Data.Map as M
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Text.IO as T
 import qualified Network.Socket as Socket
-import qualified Network.Wai.Handler.Warp as Warp
-import qualified Network.Wai.Middleware.Cors as Wai
-import qualified Servant.Server as Servant
 import qualified Snap.Http.Server as Snap
 import qualified System.Directory as Directory
 import qualified System.Environment as Env

--- a/desktop/src/Desktop/SigningApi.hs
+++ b/desktop/src/Desktop/SigningApi.hs
@@ -13,9 +13,6 @@ import qualified Network.Wai.Handler.Warp as Warp
 import qualified Network.Wai.Middleware.Cors as Wai
 import qualified Servant.Server as Servant
 
-import Desktop.Util
-
-
 signingServer
   :: MonadIO m
   => IO ()

--- a/desktop/src/Desktop/SigningApi.hs
+++ b/desktop/src/Desktop/SigningApi.hs
@@ -1,0 +1,46 @@
+module Desktop.SigningApi where
+
+import Control.Concurrent
+import qualified Control.Concurrent.Async as Async
+import Control.Exception (bracket_, bracket)
+import Control.Monad.IO.Class
+import Control.Monad.Except (throwError)
+import qualified Data.ByteString.Lazy as LBS
+import Data.Text (Text)
+import qualified Data.Text.Encoding as T
+import Kadena.SigningApi (SigningRequest, SigningResponse, signingAPI)
+import qualified Network.Wai.Handler.Warp as Warp
+import qualified Network.Wai.Middleware.Cors as Wai
+import qualified Servant.Server as Servant
+
+import Desktop.Util
+
+
+signingServer
+  :: MonadIO m
+  => IO ()
+  -> IO ()
+  -> m (MVar SigningRequest, MVar (Either Text SigningResponse))
+signingServer moveToForeground moveToBackground = do
+  signingLock <- liftIO newEmptyMVar -- Only allow one signing request to be served at once
+  signingRequestMVar <- liftIO newEmptyMVar
+  signingResponseMVar <- liftIO newEmptyMVar
+  let runSign obj = do
+        resp <- liftIO $ bracket_ (putMVar signingLock ()) (takeMVar signingLock) $ do
+          putMVar signingRequestMVar obj -- handoff to app
+          bracket moveToForeground (const $ moveToBackground) (\_ -> takeMVar signingResponseMVar)
+        case resp of
+          Left e -> throwError $ Servant.err409
+            { Servant.errBody = LBS.fromStrict $ T.encodeUtf8 e }
+          Right v -> pure v
+      s = Warp.setPort 9467 Warp.defaultSettings
+      laxCors _ = Just $ Wai.simpleCorsResourcePolicy
+        { Wai.corsRequestHeaders = Wai.simpleHeaders }
+      apiServer
+        = Warp.runSettings s $ Wai.cors laxCors
+        $ Servant.serve signingAPI runSign
+  _ <- liftIO $ Async.async $ apiServer
+  pure (signingRequestMVar, signingResponseMVar)
+
+signingResponseHandler :: MonadIO m => MVar (Either Text SigningResponse) -> Either Text SigningResponse -> m ()
+signingResponseHandler signingResponseMVar = liftIO . putMVar signingResponseMVar

--- a/desktop/src/Desktop/Util.hs
+++ b/desktop/src/Desktop/Util.hs
@@ -1,0 +1,15 @@
+module Desktop.Util where
+
+import Control.Monad (forever)
+import Control.Concurrent (MVar, forkIO, takeMVar)
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Reflex (PerformEvent, TriggerEvent, Event, newTriggerEvent)
+
+-- | Push writes to the given 'MVar' into an 'Event'.
+mvarTriggerEvent
+  :: (PerformEvent t m, TriggerEvent t m, MonadIO m)
+  => MVar a -> m (Event t a)
+mvarTriggerEvent mvar = do
+  (e, trigger) <- newTriggerEvent
+  _ <- liftIO $ forkIO $ forever $ trigger =<< takeMVar mvar
+  pure e

--- a/frontend/src/Frontend/UI/Dialogs/AddVanityAccount.hs
+++ b/frontend/src/Frontend/UI/Dialogs/AddVanityAccount.hs
@@ -128,7 +128,7 @@ uiAddVanityAccountSettings ideL mChainId initialNotes = Workflow $ do
         -- Is passing around 'Maybe x' everywhere really a good way of doing this ?
         uiCfg Nothing ideL (userChainIdSelectWithPreselect ideL mChainId) Nothing (Just defaultTransactionGasLimit) (Identity uiAccSection)
 
-      (mSender, capabilities) <- tabPane mempty curSelection DeploymentSettingsView_Keys $
+      (mSender, signers, capabilities) <- tabPane mempty curSelection DeploymentSettingsView_Keys $
         uiSenderCapabilities ideL cChainId Nothing $ uiSenderDropdown def ideL cChainId
 
       let dPayload = fmap mkPubkeyPactData <$> dKeyPair
@@ -159,7 +159,7 @@ uiAddVanityAccountSettings ideL mChainId initialNotes = Workflow $ do
 
       pure
         ( cfg & networkCfg_setSender .~ fmapMaybe (fmap unAccountName) (updated mSender)
-        , fmap mkSettings dPayload >>= buildDeploymentSettingsResult ideL mSender cChainId capabilities ttl gasLimit code
+        , fmap mkSettings dPayload >>= buildDeploymentSettingsResult ideL mSender signers cChainId capabilities ttl gasLimit code
         , account
         )
 

--- a/frontend/src/Frontend/UI/Dialogs/AddVanityAccount.hs
+++ b/frontend/src/Frontend/UI/Dialogs/AddVanityAccount.hs
@@ -129,7 +129,7 @@ uiAddVanityAccountSettings ideL mChainId initialNotes = Workflow $ do
         uiCfg Nothing ideL (userChainIdSelectWithPreselect ideL mChainId) Nothing (Just defaultTransactionGasLimit) (Identity uiAccSection)
 
       (mSender, signers, capabilities) <- tabPane mempty curSelection DeploymentSettingsView_Keys $
-        uiSenderCapabilities ideL cChainId Nothing $ uiSenderDropdown def ideL cChainId
+        uiSenderCapabilities ideL cChainId Nothing $ uiSenderDropdown def never ideL cChainId
 
       let dPayload = fmap mkPubkeyPactData <$> dKeyPair
           code = mkPactCode <$> dAccountName
@@ -147,7 +147,7 @@ uiAddVanityAccountSettings ideL mChainId initialNotes = Workflow $ do
             , _deploymentSettingsConfig_userTab = Nothing
             , _deploymentSettingsConfig_userSections = [uiAccSection]
             , _deploymentSettingsConfig_code = code
-            , _deploymentSettingsConfig_sender = uiSenderDropdown def
+            , _deploymentSettingsConfig_sender = uiSenderDropdown def never
             , _deploymentSettingsConfig_data = payload
             , _deploymentSettingsConfig_nonce = Nothing
             , _deploymentSettingsConfig_ttl = Nothing

--- a/frontend/src/Frontend/UI/Dialogs/CallFunction.hs
+++ b/frontend/src/Frontend/UI/Dialogs/CallFunction.hs
@@ -82,7 +82,7 @@ uiCallFunction m mModule func _onClose
             , _deploymentSettingsConfig_chainId =
                 predefinedChainIdSelect $ _chainRef_chain . _moduleRef_source $ moduleRef
             , _deploymentSettingsConfig_code = fromMaybe (pure $ buildCall func []) mPactCall
-            , _deploymentSettingsConfig_sender = uiSenderDropdown def
+            , _deploymentSettingsConfig_sender = uiSenderDropdown def never
             , _deploymentSettingsConfig_data = Nothing
             , _deploymentSettingsConfig_ttl = Nothing
             , _deploymentSettingsConfig_nonce = Nothing

--- a/frontend/src/Frontend/UI/Dialogs/DeployConfirmation.hs
+++ b/frontend/src/Frontend/UI/Dialogs/DeployConfirmation.hs
@@ -153,7 +153,7 @@ uiDeployConfirmation code model = fullDeployFlow def model $ do
     , _deploymentSettingsConfig_userTab = Nothing
     , _deploymentSettingsConfig_userSections = []
     , _deploymentSettingsConfig_code = pure code
-    , _deploymentSettingsConfig_sender = uiSenderDropdown def
+    , _deploymentSettingsConfig_sender = uiSenderDropdown def never
     , _deploymentSettingsConfig_data = Nothing
     , _deploymentSettingsConfig_ttl = Nothing
     , _deploymentSettingsConfig_nonce = Nothing
@@ -234,7 +234,7 @@ fullDeployFlowWithSubmit dcfg model onPreviewConfirm runner _onClose = do
             liftIO $ T.putStrLn $ "Expected 1 response, but got " <> tshow (length n)
             pure $ This "Couldn't get a response from the node"
 
-        divClass "title" $ text "Anticipated Transaction Impact"
+        divClass "title" $ text "Anticipated Transaction Impact (dis)"
         divClass "group segment" $ do
           let tableAttrs = "style" =: "table-layout: fixed; width: 100%" <> "class" =: "table"
           elAttr "table" tableAttrs $ do

--- a/frontend/src/Frontend/UI/Dialogs/DeployConfirmation.hs
+++ b/frontend/src/Frontend/UI/Dialogs/DeployConfirmation.hs
@@ -32,12 +32,10 @@ module Frontend.UI.Dialogs.DeployConfirmation
 
   , uiDeployConfirmation
   , fullDeployFlow
-  , fullDeployFlowWithSubmit
   , deploySubmit
   ) where
 
 import Common.Foundation
-import Common.Wallet
 import Control.Concurrent (newEmptyMVar, tryTakeMVar, putMVar, killThread, forkIO, ThreadId)
 import Control.Lens
 import Control.Monad (void)
@@ -46,8 +44,6 @@ import GHC.IORef (IORef)
 import Data.Default (Default (..))
 import Data.Either (rights)
 import Data.List.NonEmpty (NonEmpty(..))
-import Data.Map (Map)
-import Data.Set (Set)
 import Data.Text (Text)
 import Data.These (These(This, That))
 import Data.Traversable (for)
@@ -61,17 +57,13 @@ import Frontend.Wallet
 import Language.Javascript.JSaddle
 import Pact.Types.PactError (PactError)
 import Pact.Types.PactValue (PactValue)
-import Pact.Types.Pretty
 import Reflex
 import Reflex.Host.Class (MonadReflexCreateTrigger)
 import Reflex.Dom
 import Reflex.Extended (tagOnPostBuild)
 import Reflex.Network.Extended (Flattenable)
 import Reflex.Network.Extended (flatten)
-import qualified Data.IntMap as IntMap
-import qualified Data.Map as Map
 import qualified Data.Text as T
-import qualified Data.Text.IO as T
 import qualified Pact.Server.ApiV1Client as Api
 import qualified Pact.Types.API as Api
 import qualified Pact.Types.Command as Pact
@@ -80,8 +72,6 @@ import qualified Text.URI as URI
 
 data DeployConfirmationConfig t = DeployConfirmationConfig
   { _deployConfirmationConfig_modalTitle :: Text
-  , _deployConfirmationConfig_previewTitle :: Text
-  , _deployConfirmationConfig_previewConfirmButtonLabel :: Text
     -- The confirmation button in the preview screen will be disabled if the network
     -- returns an error. Some processes like the signing API need to override this as the
     -- responsibility for the transaction being signed lies with the creator, not the
@@ -99,7 +89,7 @@ data DeployConfirmationConfig t = DeployConfirmationConfig
 makeClassy ''DeployConfirmationConfig
 
 instance Reflex t => Default (DeployConfirmationConfig t) where
-  def = DeployConfirmationConfig "Transaction Details" "Transaction Preview" "Create Transaction" id
+  def = DeployConfirmationConfig "Transaction Details" id
 
 type CanSubmitTransaction t m =
   ( DomBuilder t m
@@ -121,17 +111,6 @@ type CanSubmitTransaction t m =
   , DomBuilderSpace m ~ GhcjsDomSpace
   , Control.Monad.Ref.Ref m ~ IORef
   )
-
--- We may not need the Status part of the workflow, but we want to be able to reuse as
--- much of this as we can so we have this function type that will give us the event of the
--- next stage or the completion of the workflow.
-type DeployPostPreview key t m modelCfg a =
-     ChainId
-  -> DeploymentSettingsResult key
-  -> Event t ()
-  -> Event t ()
-  -> Behavior t [Either Text NodeInfo]
-  -> m (Event t (Either a (Workflow t m (Text, (Event t a, modelCfg)))))
 
 -- | Confirmation dialog for deployments.
 --
@@ -164,128 +143,47 @@ uiDeployConfirmation code model = fullDeployFlow def model $ do
     }
   pure (settingsCfg, result)
 
--- | Workflow taking the user through Config -> Preview -> Status
+-- | Workflow taking the user through Config -> Status
+-- It's the responsibility of the runner to do any previewing of the
+-- deployment before exiting to this workflow. Thankfully, uiDeploymentSettings
+-- has a preview tab.
+-- If you don't want the deployment and just need a DeploymentSettingsResult, just
+-- use uiDeploymentSettings. :)
 fullDeployFlow
   :: forall key t m model modelCfg.
      ( MonadWidget t m, Monoid modelCfg, Flattenable modelCfg t
      , HasNetwork model t
-     , HasWallet model key t
      )
   => DeployConfirmationConfig t
   -> model
   -> m (modelCfg, Event t (DeploymentSettingsResult key))
   -> Event t () -> m (modelCfg, Event t ())
-fullDeployFlow deployCfg model runner onClose =
-  (fmap . fmap) (fromMaybe ()) <$> fullDeployFlowWithSubmit deployCfg model showSubmitModal runner onClose
-  where
-    showSubmitModal chain result done _next nodes =
-      pure $ Right . deploySubmit chain result <$> nodes <@ done
-
--- | Workflow taking the user through Config -> Preview -> Status
-fullDeployFlowWithSubmit
-  :: forall key t m model modelCfg a.
-     ( MonadWidget t m, Monoid modelCfg, Flattenable modelCfg t
-     , HasNetwork model t
-     , HasWallet model key t
-     )
-  => DeployConfirmationConfig t
-  -> model
-  -> DeployPostPreview key t m modelCfg a
-  -> m (modelCfg, Event t (DeploymentSettingsResult key))
-  -> Event t () -> m (modelCfg, Event t (Maybe a))
-fullDeployFlowWithSubmit dcfg model onPreviewConfirm runner _onClose = do
+fullDeployFlow dcfg model runner _onCloseExternal = do
   rec
     onClose <- modalHeader $ dynText title
-    result <- workflow deployConfig
+    result <- workflow deployWorkflow
     let (title, (done', conf')) = fmap splitDynPure $ splitDynPure result
   conf <- flatten =<< tagOnPostBuild conf'
   let done = switch $ current done'
-  pure (conf, leftmost [Just <$> done, Nothing <$ onClose])
+  pure (conf, fold [void done, onClose])
+
   where
-    deployConfig = Workflow $ do
+    deployWorkflow = Workflow $ do
       (settingsCfg, result) <- runner
+      let bNodes = current $ model ^. network_selectedNodes
+
+      let eGotoSubmit = showSubmit <$> bNodes <@> result
+
       pure (( _deployConfirmationConfig_modalTitle dcfg
             , (never, settingsCfg)
             )
-           , attachWith deployPreview (current $ model ^. wallet_accounts) result
+           , eGotoSubmit
            )
-    deployPreview accounts result = Workflow $ do
 
-      let chain = _deploymentSettingsResult_chainId result
-      succeeded <- elClass "div" "modal__main transaction_details" $ do
-
-        transactionInputSection (pure $ _deploymentSettingsResult_code result) (pure $ _deploymentSettingsResult_command result)
-        void $ uiDeployDestination model $ predefinedChainIdDisplayed chain model
-
-        let accountsToTrack = getAccounts accounts
-              $ _deploymentSettingsResult_accountsToTrack result
-        pb <- getPostBuild
-        let localReq = case _deploymentSettingsResult_wrappedCommand result of
-              Left _e -> []
-              Right cmd -> pure $ NetworkRequest
-                { _networkRequest_cmd = cmd
-                , _networkRequest_chainRef = ChainRef Nothing chain
-                , _networkRequest_endpoint = Endpoint_Local
-                }
-        responses <- performLocalRead (model ^. network) $ localReq <$ pb
-        (errors, resp) <- fmap fanThese $ performEvent $ ffor responses $ \case
-          [(_, errorResult)] -> parseNetworkErrorResult parseWrappedBalanceChecks errorResult
-          n -> do
-            liftIO $ T.putStrLn $ "Expected 1 response, but got " <> tshow (length n)
-            pure $ This "Couldn't get a response from the node"
-
-        divClass "title" $ text "Anticipated Transaction Impact (dis)"
-        divClass "group segment" $ do
-          let tableAttrs = "style" =: "table-layout: fixed; width: 100%" <> "class" =: "table"
-          elAttr "table" tableAttrs $ do
-            el "thead" $ el "tr" $ do
-              let th = elClass "th" "table__heading" . text
-              th "Account Name"
-              th "Public Key"
-              th "Change in Balance"
-            accountBalances <- flip Map.traverseWithKey accountsToTrack $ \acc pk -> do
-              bal <- holdDyn Nothing $ leftmost [Just Nothing <$ errors, Just . Map.lookup acc . fst <$> resp]
-              pure (pk, bal)
-            el "tbody" $ void $ flip Map.traverseWithKey accountBalances $ \acc (pk, balance) -> el "tr" $ do
-              let displayBalance = \case
-                    Nothing -> "Loading..."
-                    Just Nothing -> "Error"
-                    Just (Just b) -> tshow (unAccountBalance b) <> " KDA"
-              el "td" $ text $ unAccountName acc
-              el "td" $ divClass "wallet__key" $ text $ keyToText pk
-              el "td" $ dynText $ displayBalance <$> balance
-
-        divClass "title" $ text "Raw Response"
-        _ <- divClass "group segment transaction_details__raw-response" $ runWithReplace (text "Loading...") $ leftmost
-          [ text . renderCompactText . snd <$> resp
-          , text <$> errors
-          ]
-        holdDyn False $ True <$ resp
-
-      let ignoreSuccessStatus = _deployConfirmationConfig_disregardSubmitResponse dcfg
-
-      (back, next) <- modalFooter $ do
-        back <- uiButtonDyn def $ text "Back"
-        let isDisabled = not . ignoreSuccessStatus <$> succeeded
-
-        next <- uiButtonDyn
-          (def & uiButtonCfg_class .~ "button_type_confirm" & uiButtonCfg_disabled .~ isDisabled)
-          $ text (_deployConfirmationConfig_previewConfirmButtonLabel dcfg)
-
-        pure (back, next)
-
-      let done = gate (current $ fmap ignoreSuccessStatus succeeded) next
-
-      (eDoneAfterConfirm, eNextWorkflow) <- fanEither
-        <$> onPreviewConfirm chain result done next (current $ model ^. network_selectedNodes)
-
-      pure
-        ( (_deployConfirmationConfig_previewTitle dcfg, (eDoneAfterConfirm, mempty))
-        , leftmost
-          [ deployConfig <$ back
-          , eNextWorkflow
-          ]
-        )
+    showSubmit nodes result = deploySubmit
+      (_deploymentSettingsResult_chainId result)
+      result
+      nodes
 
 deploySubmit
   :: forall key t m a modelCfg.
@@ -325,12 +223,6 @@ statusText = \case
   Status_Working -> "working"
   Status_Failed -> "failed"
   Status_Done -> "done"
-
-getAccounts :: Accounts key -> Set AccountName -> Map AccountName PublicKey
-getAccounts accounts = Map.restrictKeys (IntMap.foldr f Map.empty accounts)
-  where f = \case
-          SomeAccount_Deleted -> id
-          SomeAccount_Account a -> Map.insert (_account_name a) $ _keyPair_publicKey $ _account_key a
 
 data TransactionSubmitFeedback t = TransactionSubmitFeedback
   { _transactionSubmitFeedback_sendStatus :: Dynamic t Status

--- a/frontend/src/Frontend/UI/Dialogs/Send.hs
+++ b/frontend/src/Frontend/UI/Dialogs/Send.hs
@@ -1,22 +1,22 @@
-{-# LANGUAGE ApplicativeDo         #-}
-{-# LANGUAGE ConstraintKinds       #-}
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE DeriveGeneric         #-}
-{-# LANGUAGE ExtendedDefaultRules  #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE KindSignatures        #-}
-{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE ExtendedDefaultRules #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE PatternGuards         #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE QuasiQuotes           #-}
-{-# LANGUAGE RecursiveDo           #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE StandaloneDeriving    #-}
-{-# LANGUAGE TemplateHaskell       #-}
-{-# LANGUAGE TupleSections         #-}
-{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RecursiveDo #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- | Dialog for sending money between accounts
 -- Copyright   :  (C) 2019 Kadena
@@ -209,7 +209,7 @@ sendConfig model sender = Workflow $ do
               divClass "label labeled-input__label" $ text "Account Name"
               let cfg = def & dropdownConfig_attributes .~ pure ("class" =: "labeled-input__input")
                   chain = pure $ Just $ _account_chainId sender
-              gasAcc <- uiSenderDropdown cfg model chain
+              gasAcc <- uiSenderDropdown cfg never model chain
               let toAccount ma m = find ((ma ==) . Just . _account_name) $ fmapMaybe (\case SomeAccount_Account a -> Just a; _ -> Nothing) m
               pure $ toAccount <$> gasAcc <*> model ^. wallet_accounts
       pure (conf, mCaps, recipient)

--- a/frontend/src/Frontend/UI/Dialogs/Signing.hs
+++ b/frontend/src/Frontend/UI/Dialogs/Signing.hs
@@ -63,7 +63,7 @@ uiSigning appCfg ideL signingRequest onCloseExternal = do
           , _deploymentSettingsConfig_code = pure $ _signingRequest_code signingRequest
           , _deploymentSettingsConfig_sender = case _signingRequest_sender signingRequest of
               Just sender -> \_ _ -> uiSenderFixed sender
-              Nothing -> uiSenderDropdown def
+              Nothing -> uiSenderDropdown def never
           , _deploymentSettingsConfig_data = _signingRequest_data signingRequest
           , _deploymentSettingsConfig_nonce = _signingRequest_nonce signingRequest
           , _deploymentSettingsConfig_ttl = _signingRequest_ttl signingRequest

--- a/frontend/src/Frontend/UI/Dialogs/Signing.hs
+++ b/frontend/src/Frontend/UI/Dialogs/Signing.hs
@@ -27,7 +27,6 @@ import Frontend.Foundation hiding (Arg)
 import Frontend.JsonData
 import Frontend.Network
 import Frontend.UI.DeploymentSettings
-import Frontend.UI.Dialogs.DeployConfirmation (DeployConfirmationConfig (..), fullDeployFlowWithSubmit)
 import Frontend.UI.Modal.Impl
 import Frontend.Wallet
 
@@ -53,50 +52,41 @@ uiSigning
   -> Event t ()
   -> m (mConf, Event t ())
 uiSigning appCfg ideL signingRequest onCloseExternal = do
-  let runner = do
-        (mConf, result, _) <- uiDeploymentSettings ideL $ DeploymentSettingsConfig
-          { _deploymentSettingsConfig_chainId = case _signingRequest_chainId signingRequest of
-              Just c -> predefinedChainIdDisplayed c
-              Nothing -> userChainIdSelect
-          , _deploymentSettingsConfig_userTab = Nothing
-          , _deploymentSettingsConfig_userSections = []
-          , _deploymentSettingsConfig_code = pure $ _signingRequest_code signingRequest
-          , _deploymentSettingsConfig_sender = case _signingRequest_sender signingRequest of
-              Just sender -> \_ _ -> uiSenderFixed sender
-              Nothing -> uiSenderDropdown def never
-          , _deploymentSettingsConfig_data = _signingRequest_data signingRequest
-          , _deploymentSettingsConfig_nonce = _signingRequest_nonce signingRequest
-          , _deploymentSettingsConfig_ttl = _signingRequest_ttl signingRequest
-          , _deploymentSettingsConfig_gasLimit = _signingRequest_gasLimit signingRequest
-          , _deploymentSettingsConfig_caps = Just $ _signingRequest_caps signingRequest
-          , _deploymentSettingsConfig_extraSigners = fromPactPublicKey <$> fromMaybe [] (_signingRequest_extraSigners signingRequest)
-          , _deploymentSettingsConfig_includePreviewTab = True
-          }
-        pure (mConf, result)
+  onClose <- modalHeader $ text "Signing Request"
 
+  (mConf, result, _) <- uiDeploymentSettings ideL $ DeploymentSettingsConfig
+    { _deploymentSettingsConfig_chainId = case _signingRequest_chainId signingRequest of
+        Just c -> predefinedChainIdDisplayed c
+        Nothing -> userChainIdSelect
+    , _deploymentSettingsConfig_userTab = Nothing
+    , _deploymentSettingsConfig_userSections = []
+    , _deploymentSettingsConfig_code = pure $ _signingRequest_code signingRequest
+    , _deploymentSettingsConfig_sender = case _signingRequest_sender signingRequest of
+        Just sender -> \_ _ -> uiSenderFixed sender
+        Nothing -> uiSenderDropdown def never
+    , _deploymentSettingsConfig_data = _signingRequest_data signingRequest
+    , _deploymentSettingsConfig_nonce = _signingRequest_nonce signingRequest
+    , _deploymentSettingsConfig_ttl = _signingRequest_ttl signingRequest
+    , _deploymentSettingsConfig_gasLimit = _signingRequest_gasLimit signingRequest
+    , _deploymentSettingsConfig_caps = Just $ _signingRequest_caps signingRequest
+    , _deploymentSettingsConfig_extraSigners = fromPactPublicKey <$> fromMaybe [] (_signingRequest_extraSigners signingRequest)
+    , _deploymentSettingsConfig_includePreviewTab = True
+    }
 
-  (conf, done) <- fullDeployFlowWithSubmit
-    (DeployConfirmationConfig "Signing Request" "Signing Preview" "Confirm Signature" disregardSuccessStatus)
-    ideL
-    signSubmit
-    runner
-    onCloseExternal
+  let response = deploymentResToResponse <$> result
 
   finished <- performEvent . fmap (liftJSM . _appCfg_signingResponse appCfg) <=< headE $
-    maybe (Left "Cancelled") Right <$> leftmost [done, Nothing <$ onCloseExternal]
+    maybe (Left "Cancelled") Right <$> leftmost
+      [ Just <$> response
+      , Nothing <$ onCloseExternal
+      , Nothing <$ onClose
+      ]
 
-  pure (conf, finished)
+  pure (mConf, finished)
+
   where
-    -- The confirm process should proceed regardless of the response from the network, the
-    -- failure of this is the responsibility of the dApp. This ensures the confirm button
-    -- is not disabled and that the network response is treated as a "success"
-    disregardSuccessStatus = (|| True)
-
-    signSubmit _chain result _done next _nodes = do
-      let sign = SigningResponse
-            { _signingResponse_chainId = _deploymentSettingsResult_chainId result
-            , _signingResponse_body = _deploymentSettingsResult_command result
-            }
-      -- This is the end of our work flow, so return our done event on the completion of the signing.
-      -- Should some feedback be added to this to ensure that people don't spam the button?
-      pure $ Left sign <$ next
+    deploymentResToResponse result =
+      SigningResponse
+        { _signingResponse_chainId = _deploymentSettingsResult_chainId result
+        , _signingResponse_body = _deploymentSettingsResult_command result
+        }


### PR DESCRIPTION
Done:
- Hides the empty capability line behind the addButton
- Signers list coming from capability and also the checkbox UI
- Apply All button to apply gas capability account to all other capabilities
- Drop restriction of only showing accounts for the selected chain in signing ui
- Puts the signing warp server in dev desktop setup
- Cuts fullDeploy out of signing dialog as uiDeploymentSettings is enough now
- Trims fullDeploy down (don't need withSubmit anymore with signing self sufficient)

Todo:
- Full testing (I've played parrots a bit, but want to do deployments and poke around a lot)

Later (I'll make an Asana for it):
- The signing server seems to get stuck when ob restarts