### PR TITLE
Fixes to balance retrieval and positive real input

### DIFF
--- a/frontend/src/Frontend/UI/Widgets.hs
+++ b/frontend/src/Frontend/UI/Widgets.hs
@@ -63,6 +63,7 @@ import           Data.Either (isLeft)
 import           Data.Map.Strict             (Map)
 import qualified Data.Map.Strict as Map
 import           Data.String                 (IsString)
+import           Data.Proxy                  (Proxy(..))
 import           Data.Text                   (Text)
 import qualified Data.Text                   as T
 import           GHC.Word                    (Word8)
@@ -107,16 +108,17 @@ uiCheckbox cls b cfg c =
 -- | Create an editable checkbox
 --   Note: if the "type" or "checked" attributes are provided as attributes, they will be ignored
 {-# INLINABLE checkbox' #-}
-checkbox' :: (DomBuilder t m, PostBuild t m) => Bool -> CheckboxConfig t -> m (Checkbox t)
+checkbox' :: forall t m. (DomBuilder t m, PostBuild t m) => Bool -> CheckboxConfig t -> m (Checkbox t)
 checkbox' checked config = do
   let permanentAttrs = "type" =: "checkbox"
       dAttrs = Map.delete "checked" . Map.union permanentAttrs <$> _checkboxConfig_attributes config
   modifyAttrs <- dynamicAttributesToModifyAttributes dAttrs
-  i <- inputElement $ def
+  i <- inputElement $ (def :: InputElementConfig EventResult t (DomBuilderSpace m))
     & inputElementConfig_initialChecked .~ checked
     & inputElementConfig_setChecked .~ _checkboxConfig_setValue config
     & inputElementConfig_elementConfig . elementConfig_initialAttributes .~ Map.mapKeys (AttributeName Nothing) permanentAttrs
     & inputElementConfig_elementConfig . elementConfig_modifyAttributes .~ fmap mapKeysToAttributeName modifyAttrs
+    & inputElementConfig_elementConfig . elementConfig_eventSpec %~ addEventSpecFlags (Proxy :: Proxy (DomBuilderSpace m)) Click (const stopPropagation)
   return $ Checkbox
     { _checkbox_value = _inputElement_checked i
     , _checkbox_change = _inputElement_checkedChange i

--- a/frontend/src/Frontend/UI/Widgets.hs
+++ b/frontend/src/Frontend/UI/Widgets.hs
@@ -198,27 +198,41 @@ uiRealInputElement cfg = do
         (<> ("type" =: "number")) . addInputElementCls . addNoAutofillAttrs
 
 uiCorrectingInputElement
-  :: forall t m a er explanation. DomBuilder t m
+  :: forall t m a explanation. DomBuilder t m
   => MonadFix m
   => (Text -> Maybe a)
   -> (a -> Maybe (a, explanation))
+  -> (a -> Maybe (a, explanation))
   -> (a -> Text)
-  -> InputElementConfig er t (DomBuilderSpace m)
-  -> m (InputElement er (DomBuilderSpace m) t, Dynamic t (Maybe a), Event t (a, Maybe explanation))
-uiCorrectingInputElement parse sanitize render cfg = mdo
-  ie <- inputElement $ cfg & inputElementConfig_setValue %~ (\e -> leftmost [attemptCorrection e, forceCorrection inp])
+  -> InputElementConfig EventResult t (DomBuilderSpace m)
+  -> m (InputElement EventResult (DomBuilderSpace m) t, Dynamic t (Maybe a), Event t (a, Maybe explanation))
+uiCorrectingInputElement parse inputSanitize blurSanitize render cfg = mdo
+  ie <- inputElement $ cfg & inputElementConfig_setValue %~ (\e -> leftmost
+      [ attemptCorrection e
+      , forceCorrection inp
+      , blurAttemptCorrection eBlurredVal
+      , blurForceCorrection eBlurredVal
+      ]
+    )
   let
     inp = _inputElement_input ie
     val = value ie
+    eBlurredVal = current val <@ domEvent Blur ie
 
-    sanitization :: Functor f => f Text -> f (Maybe (a, Maybe explanation))
-    sanitization = fmap $ \i -> ffor (parse i) $ \p ->
-      case sanitize p of
+    sanitization :: Functor f => (a -> Maybe (a, explanation)) -> f Text -> f (Maybe (a, Maybe explanation))
+    sanitization f = fmap $ \i -> ffor (parse i) $ \p ->
+      case f p of
         Nothing -> (p, Nothing)
         Just (a, x) -> (a, Just x)
 
+    inputSanitization :: Functor f => f Text -> f (Maybe (a, Maybe explanation))
+    inputSanitization = sanitization inputSanitize
+
+    blurSanitization :: Functor f => f Text -> f (Maybe (a, Maybe explanation))
+    blurSanitization = sanitization blurSanitize
+
     intercept :: ((a, Maybe explanation) -> Bool) -> (Event t Text -> Event t Text)
-    intercept p = fmap render . fmap fst . ffilter p . fmapMaybe id . sanitization
+    intercept p = fmap render . fmap fst . ffilter p . fmapMaybe id . inputSanitization
 
     attemptCorrection :: Event t Text -> Event t Text
     attemptCorrection = intercept (const True)
@@ -226,22 +240,31 @@ uiCorrectingInputElement parse sanitize render cfg = mdo
     forceCorrection :: Event t Text -> Event t Text
     forceCorrection = intercept (isJust . snd)
 
-    -- type inference goes crazy if we inline this - ghc bug?
-    inp' = fmapMaybe id $ sanitization inp
+    blurIntercept :: ((a, Maybe explanation) -> Bool) -> (Event t Text -> Event t Text)
+    blurIntercept p = fmap render . fmap fst . ffilter p . fmapMaybe id . blurSanitization
 
-  pure (ie, (fmap . fmap) fst $ sanitization val, inp')
+    blurAttemptCorrection :: Event t Text -> Event t Text
+    blurAttemptCorrection = blurIntercept (const True)
+
+    blurForceCorrection :: Event t Text -> Event t Text
+    blurForceCorrection = blurIntercept (isJust . snd)
+
+    -- type inference goes crazy if we inline this - ghc bug?
+    inp' = fmapMaybe id $ inputSanitization inp
+
+  pure (ie, (fmap . fmap) fst $ inputSanitization val, inp')
 
 -- | Decimal input to the given precision. Returns the element, the value, and
 -- the user input events
 uiNonnegativeRealWithPrecisionInputElement
-  :: forall t m er a. (DomBuilder t m, MonadFix m, MonadHold t m)
+  :: forall t m a. (DomBuilder t m, MonadFix m, MonadHold t m)
   => Word8
   -> (Decimal -> a)
-  -> InputElementConfig er t (DomBuilderSpace m)
-  -> m (InputElement er (DomBuilderSpace m) t, Dynamic t (Maybe a), Event t a)
+  -> InputElementConfig EventResult t (DomBuilderSpace m)
+  -> m (InputElement EventResult (DomBuilderSpace m) t, Dynamic t (Maybe a), Event t a)
 uiNonnegativeRealWithPrecisionInputElement prec fromDecimal cfg = do
   rec
-    (ie, val, input) <- uiCorrectingInputElement parse sanitize tshow $ cfg
+    (ie, val, input) <- uiCorrectingInputElement parse inputSanitize blurSanitize tshow $ cfg
       & initialAttributes %~ addInputElementCls . addNoAutofillAttrs
         . (<> ("type" =: "number" <> "step" =: stepSize <> "min" =: stepSize))
     widgetHold_ blank $ ffor (fmap snd input) $ traverse_ $
@@ -252,14 +275,18 @@ uiNonnegativeRealWithPrecisionInputElement prec fromDecimal cfg = do
     stepSize = "0." <> T.replicate (fromIntegral prec - 1) "0" <> "1"
     parse = tread
 
-    sanitize :: Decimal -> Maybe (Decimal, Text)
-    sanitize decimal = asum
+    blurSanitize :: Decimal -> Maybe (Decimal, Text)
+    blurSanitize decimal = asum
+      [ (D.roundTo 1 decimal, "")
+        <$ guard (D.decimalPlaces decimal == 0) -- To avoid `: Failure: Type error: expected decimal, found integer`
+      ]
+
+    inputSanitize :: Decimal -> Maybe (Decimal, Text)
+    inputSanitize decimal = asum
       [ (0, "Cannot be negative")
         <$ guard (decimal < 0)
       , (D.roundTo prec decimal, ("Rounded to " <> tshow prec <> " places"))
         <$ guard (D.decimalPlaces decimal > prec)
-      , (D.roundTo 1 decimal, "")
-        <$ guard (D.decimalPlaces decimal == 0) -- To avoid `: Failure: Type error: expected decimal, found integer`
       ]
 
 -- TODO: correct floating point decimals
@@ -268,10 +295,10 @@ uiIntInputElement
   => MonadFix m
   => Maybe Integer
   -> Maybe Integer
-  -> InputElementConfig er t (DomBuilderSpace m)
-  -> m (InputElement er (DomBuilderSpace m) t, Event t Integer)
+  -> InputElementConfig EventResult t (DomBuilderSpace m)
+  -> m (InputElement EventResult (DomBuilderSpace m) t, Event t Integer)
 uiIntInputElement mmin mmax cfg = do
-    (r, _, input) <- uiCorrectingInputElement (tread . fixNum) sanitize tshow $ cfg & initialAttributes %~
+    (r, _, input) <- uiCorrectingInputElement (tread . fixNum) sanitize (const Nothing) tshow $ cfg & initialAttributes %~
       ((<> numberAttrs) . addInputElementCls . addNoAutofillAttrs)
 
     pure (r

--- a/frontend/src/Frontend/Wallet.hs
+++ b/frontend/src/Frontend/Wallet.hs
@@ -282,7 +282,7 @@ getBalances model accounts = do
     accountBalanceReq acc = "(coin.get-balance " <> tshow (unAccountName acc) <> ")"
     mkReqs :: (NetworkName, PublicMeta) -> Accounts key -> Performable m (IntMap (SomeAccount key, Maybe NetworkRequest))
     mkReqs meta someaccs = for someaccs $ \sa ->
-      fmap (sa,) . traverse (mkReq meta) $ activeAccountOnNetwork (fst meta) sa
+      fmap (sa,) . traverse (mkReq meta) $ someAccount Nothing Just sa
     mkReq (netName, pm) acc = mkSimpleReadReq (accountBalanceReq $ _account_name acc) netName pm (ChainRef Nothing $ _account_chainId acc)
 
 


### PR DESCRIPTION
Also on top of #287 because everything is in chaos atm. Lol. 

This disables the filtering of balance refresh to the current network because that was weirdly broken meaning that if you had two networks then one wouldn't get the balances properly even when switching the dropdown. Errors from trying the wrong network are better than missing balances.

Changing the rounding done by #278 to only happen on blur. Much nicer for the user. :)