### PR TITLE
Signing Screen Fixes

### DIFF
--- a/frontend/src/Frontend/UI/DeploymentSettings.hs
+++ b/frontend/src/Frontend/UI/DeploymentSettings.hs
@@ -61,7 +61,7 @@ module Frontend.UI.DeploymentSettings
   , Identity (runIdentity)
   ) where
 
-import Control.Applicative ((<|>),liftA2)
+import Control.Applicative ((<|>))
 import Control.Arrow (first, (&&&))
 import Control.Error (fmapL, hoistMaybe, headMay)
 import Control.Error.Util (hush)


### PR DESCRIPTION
Rename 'Signing Accounts' with 'Unrestricted'.
Rename 'Apply all' to 'Apply gas payer to all'.
Hide apply all button unless there is more than one capability.