### PR TITLE
Unify KDA input fields to a single widget, allow for input of '.9' as well as '0.9'

### DIFF
--- a/frontend/src/Frontend/UI/DeploymentSettings.hs
+++ b/frontend/src/Frontend/UI/DeploymentSettings.hs
@@ -599,15 +599,13 @@ uiMetaData m mTTL mGasLimit = do
         :: Event t Text
         -> InputElementConfig EventResult t (DomBuilderSpace m)
         -> m (Event t GasPrice)
-      gasPriceInputBox setExternal conf = fmap (view _3) $ dimensionalInputWrapper "KDA" $
-       uiNonnegativeRealWithPrecisionInputElement maxCoinPrecision (GasPrice . ParsedDecimal) $ conf
+      gasPriceInputBox setExternal conf = fmap (view _3) $ uiGasPriceInputField $ conf
         & initialAttributes %~ addToClassAttr "input-units"
         & inputElementConfig_initialValue .~ showGasPrice defaultTransactionGasPrice
         & inputElementConfig_setValue .~ leftmost
           [ setExternal
           , showGasPrice <$> pbGasPrice -- Initial value (from storage)
           ]
-        & inputElementConfig_elementConfig . elementConfig_eventSpec %~ preventScrollWheelAndUpDownArrow @m
 
     onGasPrice <- mdo
       tsEl <- mkLabeledClsInput True "Transaction Speed" (txnSpeedSliderEl setPrice)

--- a/frontend/src/Frontend/UI/DeploymentSettings.hs
+++ b/frontend/src/Frontend/UI/DeploymentSettings.hs
@@ -632,8 +632,9 @@ uiMetaData m mTTL mGasLimit = do
 
     gasLimit <- holdDyn initGasLimit $ leftmost [onGasLimit, pbGasLimit]
 
-    let mkTransactionFee c = fmap (view _1) $ dimensionalInputWrapper "KDA" $ uiNonnegativeRealWithPrecisionInputElement maxCoinPrecision id $ c
+    let mkTransactionFee c = fmap (view _1) $ uiGasPriceInputField $ c
           & initialAttributes %~ Map.insert "disabled" ""
+
     _ <- mkLabeledInputView True "Max Transaction Fee"  mkTransactionFee $
       ffor (m ^. network_meta) $ \pm -> showGasPrice $ fromIntegral (_pmGasLimit pm) * _pmGasPrice pm
 

--- a/frontend/src/Frontend/UI/Dialogs/Receive.hs
+++ b/frontend/src/Frontend/UI/Dialogs/Receive.hs
@@ -110,7 +110,6 @@ uiReceiveFromLegacyAccount model = do
   chain <- divClass "account-details__receive-from-chain" $ userChainIdSelect model
 
   amount <- view _2 <$> mkLabeledInput True "Amount" uiGasPriceInputField def
-    -- (uiNonnegativeRealWithPrecisionInputElement maxCoinPrecision id) def
 
   pure $ (\macc mc mamnt mkeypair -> LegacyTransferInfo <$> macc <*> mc <*> mamnt <*> mkeypair)
     <$> mAccountName

--- a/frontend/src/Frontend/UI/Widgets.hs
+++ b/frontend/src/Frontend/UI/Widgets.hs
@@ -284,7 +284,6 @@ uiNonnegativeRealWithPrecisionInputElement prec fromDecimal cfg = do
 
   where
     stepSize = "0." <> T.replicate (fromIntegral prec - 1) "0" <> "1"
-    -- parse = tread
     parse t = tread $
       if "." `T.isPrefixOf` t && not (T.any (== '.') $ T.tail t) then
         T.cons '0' t

--- a/frontend/src/Frontend/UI/Widgets.hs
+++ b/frontend/src/Frontend/UI/Widgets.hs
@@ -284,7 +284,12 @@ uiNonnegativeRealWithPrecisionInputElement prec fromDecimal cfg = do
 
   where
     stepSize = "0." <> T.replicate (fromIntegral prec - 1) "0" <> "1"
-    parse = tread
+    -- parse = tread
+    parse t = tread $
+      if "." `T.isPrefixOf` t && not (T.any (== '.') $ T.tail t) then
+        T.cons '0' t
+      else
+        t
 
     blurSanitize :: Decimal -> Maybe (Decimal, Text)
     blurSanitize decimal = asum


### PR DESCRIPTION
Add a single purpose widget to be the go to input field when dealing with the KDA
values. This field contains the 'KDA' prefix on the field, the non-negative precision
handling using the coin precision, and also prevents the use of mouse-wheel or up/down
arrows to manipulate the value.

Call Function amount input field is unaffected.