### PR TITLE
Change default gas price and gas limit.

### DIFF
--- a/frontend/src/Frontend/Network.hs
+++ b/frontend/src/Frontend/Network.hs
@@ -390,12 +390,11 @@ getSelectedNetworkInfos networkL = do
     errNets <- sample $ current $ networkL ^. network_selectedNodes
     pure $ rights errNets
 
--- This is the minimum precision allowed by the Pact language:
--- https://github.com/kadena-io/chainweb-node/commit/ee8a0db079869b39e23be1ef6737f0a7795eff87#diff-6c59a5fb9f1b0b8b470cb50e8bd643ebR54
 defaultTransactionGasPrice :: GasPrice
-defaultTransactionGasPrice = GasPrice $ ParsedDecimal $ Decimal maxCoinPrecision 1
+defaultTransactionGasPrice = GasPrice $ ParsedDecimal $ Decimal 5 1
 
--- | As defined in the coin contract
+-- | This is the minimum precision allowed by the Pact language, as defined in the coin contract:
+-- https://github.com/kadena-io/chainweb-node/commit/ee8a0db079869b39e23be1ef6737f0a7795eff87#diff-6c59a5fb9f1b0b8b470cb50e8bd643ebR54
 maxCoinPrecision :: Word8
 maxCoinPrecision = 12
 
@@ -404,10 +403,10 @@ defaultTransactionTTL = TTLSeconds (8 * 60 * 60) -- 8 hours
 
 -- Taken from https://github.com/kadena-io/chainweb-node/blob/85688ea0182d1b1ab0d8d784a48b4851a950ec7a/src/Chainweb/Chainweb.hs#L344
 chainwebGasLimit :: Num a => a
-chainwebGasLimit = 1e5
+chainwebGasLimit = 600
 
 defaultTransactionGasLimit :: GasLimit
-defaultTransactionGasLimit = GasLimit 1e5
+defaultTransactionGasLimit = GasLimit chainwebGasLimit
 
 
 buildMeta

--- a/frontend/src/Frontend/Network.hs
+++ b/frontend/src/Frontend/Network.hs
@@ -62,7 +62,7 @@ module Frontend.Network
   , getNetworkNameAndMeta
   , getCreationTime
     -- * Defaults
-  , chainwebGasLimit
+  , chainwebGasLimitMaximum
   , defaultTransactionGasLimit
   , defaultTransactionGasPrice
   , maxCoinPrecision
@@ -402,11 +402,11 @@ defaultTransactionTTL :: TTLSeconds
 defaultTransactionTTL = TTLSeconds (8 * 60 * 60) -- 8 hours
 
 -- Taken from https://github.com/kadena-io/chainweb-node/blob/85688ea0182d1b1ab0d8d784a48b4851a950ec7a/src/Chainweb/Chainweb.hs#L344
-chainwebGasLimit :: Num a => a
-chainwebGasLimit = 600
+chainwebGasLimitMaximum :: Num a => a
+chainwebGasLimitMaximum = 1e5
 
 defaultTransactionGasLimit :: GasLimit
-defaultTransactionGasLimit = GasLimit chainwebGasLimit
+defaultTransactionGasLimit = GasLimit 600
 
 
 buildMeta

--- a/frontend/src/Frontend/UI/DeploymentSettings.hs
+++ b/frontend/src/Frontend/UI/DeploymentSettings.hs
@@ -682,10 +682,10 @@ uiMetaData m mTTL mGasLimit = do
          in GasPrice $ ParsedDecimal $ roundTo maxCoinPrecision gp
 
       scaleTxnSpeedToGP :: GasPrice -> GasPrice
-      scaleTxnSpeedToGP = shiftGP 1 1001 (1e-12) (1e-8)
+      scaleTxnSpeedToGP = shiftGP 1 1001 (1e-12) (1e-5)
 
       scaleGPtoTxnSpeed :: GasPrice -> GasPrice
-      scaleGPtoTxnSpeed = shiftGP (1e-12) (1e-8) 1 1001
+      scaleGPtoTxnSpeed = shiftGP (1e-12) (1e-5) 1 1001
 
       parseGasPrice :: Text -> Maybe GasPrice
       parseGasPrice t = GasPrice . ParsedDecimal . roundTo maxCoinPrecision <$> readMay (T.unpack t)

--- a/frontend/src/Frontend/UI/DeploymentSettings.hs
+++ b/frontend/src/Frontend/UI/DeploymentSettings.hs
@@ -682,10 +682,10 @@ uiMetaData m mTTL mGasLimit = do
          in GasPrice $ ParsedDecimal $ roundTo maxCoinPrecision gp
 
       scaleTxnSpeedToGP :: GasPrice -> GasPrice
-      scaleTxnSpeedToGP = shiftGP 1 1001 (1e-12) (1e-5)
+      scaleTxnSpeedToGP = shiftGP 1 1001 (1e-12) (1e-3)
 
       scaleGPtoTxnSpeed :: GasPrice -> GasPrice
-      scaleGPtoTxnSpeed = shiftGP (1e-12) (1e-5) 1 1001
+      scaleGPtoTxnSpeed = shiftGP (1e-12) (1e-3) 1 1001
 
       parseGasPrice :: Text -> Maybe GasPrice
       parseGasPrice t = GasPrice . ParsedDecimal . roundTo maxCoinPrecision <$> readMay (T.unpack t)

--- a/frontend/src/Frontend/UI/DeploymentSettings.hs
+++ b/frontend/src/Frontend/UI/DeploymentSettings.hs
@@ -626,7 +626,7 @@ uiMetaData m mTTL mGasLimit = do
       mkGasLimitInput
         :: InputElementConfig EventResult t (DomBuilderSpace m)
         -> m (Event t Integer)
-      mkGasLimitInput conf = dimensionalInputWrapper "Units" $ fmap snd $ uiIntInputElement (Just 0) (Just chainwebGasLimit) $ conf
+      mkGasLimitInput conf = dimensionalInputWrapper "Units" $ fmap snd $ uiIntInputElement (Just 0) (Just chainwebGasLimitMaximum) $ conf
         & inputElementConfig_initialValue .~ showGasLimit initGasLimit
         & inputElementConfig_setValue .~ fmap showGasLimit pbGasLimit
         & inputElementConfig_elementConfig . elementConfig_eventSpec %~ preventScrollWheelAndUpDownArrow @m


### PR DESCRIPTION
Update scaling function for transaction price slider.

The slider doesn't scale the gas price as smoothly as it did before because of the expanded range.