### PR TITLE
Optimistic vanity accounts

### DIFF
--- a/frontend/src/Frontend/UI/DeploymentSettings.hs
+++ b/frontend/src/Frontend/UI/DeploymentSettings.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE RecursiveDo #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -61,7 +62,7 @@ module Frontend.UI.DeploymentSettings
   , Identity (runIdentity)
   ) where
 
-import Control.Applicative ((<|>))
+import Control.Applicative ((<|>), empty)
 import Control.Arrow (first, (&&&))
 import Control.Error (fmapL, hoistMaybe, headMay)
 import Control.Error.Util (hush)
@@ -218,6 +219,12 @@ publicKeysForAccounts allAccounts caps =
   in
     Map.fromList $ fmapMaybe toPublicKey $ Map.toList caps
 
+lookupAccountByName :: ChainId -> AccountName -> Accounts key -> Maybe (Account key)
+lookupAccountByName c n = fmap getFirst . foldMap f
+  where f = \case
+          SomeAccount_Account a | _account_name a == n, _account_chainId a == c -> Just $ First a
+          _ -> Nothing
+
 buildDeploymentSettingsResult
   :: ( HasNetwork model t
      , HasJsonData model t
@@ -258,6 +265,14 @@ buildDeploymentSettingsResult m mSender signers cChainId capabilities ttl gasLim
         }
   code' <- lift code
   allAccounts <- lift $ m ^. wallet_accounts
+  -- Make an effort to ensure the sender account has enough balance to actually
+  -- pay the gas. This won't work if the user selects an account on a different
+  -- chain, but that's another issue.
+  for_ (lookupAccountByName chainId sender allAccounts) $ \senderAccount -> case _account_balance senderAccount of
+    Nothing -> empty
+    Just b -> let GasLimit lim = _pmGasLimit publicMeta
+                  GasPrice (ParsedDecimal price) = _pmGasPrice publicMeta
+               in guard $ unAccountBalance b > fromIntegral lim * price
   let pkCaps = publicKeysForAccounts allAccounts caps
   pure $ do
     let signingPairs = getSigningPairs signing allAccounts
@@ -826,7 +841,7 @@ capabilityInputRow
   -> m (Dynamic t (Maybe AccountName))
   -> m (CapabilityInputRow t)
 capabilityInputRow mCap mkSender = elClass "tr" "table__row" $ do
-  (empty, parsed) <- elClass "td" "table__cell_padded" $ mdo
+  (emptyCap, parsed) <- elClass "td" "table__cell_padded" $ mdo
     cap <- uiInputElement $ def
       & inputElementConfig_initialValue .~ foldMap (renderCompactText . _dappCap_cap) mCap
       & initialAttributes .~
@@ -837,19 +852,19 @@ capabilityInputRow mCap mkSender = elClass "tr" "table__row" $ do
           , dis
           ])
       & modifyAttributes .~ ffor errors (\e -> "style" =: ("background-color: #fdd" <$ guard e))
-    empty <- holdUniqDyn $ T.null <$> value cap
+    emptyCap <- holdUniqDyn $ T.null <$> value cap
     let parsed = parseSigCapability <$> value cap
-        showError = (\p e -> isLeft p && not e) <$> parsed <*> empty
+        showError = (\p e -> isLeft p && not e) <$> parsed <*> emptyCap
         errors = leftmost
           [ tag (current showError) (domEvent Blur cap)
           , False <$ _inputElement_input cap
           ]
-    pure (empty, parsed)
+    pure (emptyCap, parsed)
   account <- elClass "td" "table__cell_padded" mkSender
 
   pure $ CapabilityInputRow
-    { _capabilityInputRow_empty = empty
-    , _capabilityInputRow_value = empty >>= \case
+    { _capabilityInputRow_empty = emptyCap
+    , _capabilityInputRow_value = emptyCap >>= \case
       True -> pure mempty
       False -> fmap (fromMaybe mempty) $ runMaybeT $ do
         a <- MaybeT account

--- a/frontend/src/Frontend/UI/Dialogs/AddVanityAccount.hs
+++ b/frontend/src/Frontend/UI/Dialogs/AddVanityAccount.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE RecursiveDo #-}
 {-# LANGUAGE TupleSections #-}
 module Frontend.UI.Dialogs.AddVanityAccount
@@ -9,15 +10,18 @@ import           Control.Applicative                    (liftA2)
 import           Control.Lens                           ((^.))
 import           Control.Monad.Trans.Class              (lift)
 import           Control.Monad.Trans.Maybe              (MaybeT (..), runMaybeT)
-import           Data.Either                            (isLeft)
 import           Data.Functor.Identity                  (Identity(..))
-import           Data.Maybe                             (isNothing, maybe)
+import           Data.Maybe                             (isNothing)
 import           Data.Text                              (Text)
 
 import           Data.Aeson                             (Object,
                                                          Value (Array, String))
 import qualified Data.HashMap.Strict                    as HM
 import qualified Data.Vector                            as V
+
+import Pact.Types.PactValue
+import Pact.Types.Exp
+import Data.These.Combinators
 
 import           Reflex
 import           Reflex.Dom.Contrib.CssClass            (renderClass)
@@ -26,8 +30,7 @@ import           Reflex.Dom.Core
 import           Reflex.Network.Extended                (Flattenable)
 
 import           Frontend.UI.DeploymentSettings
-import           Frontend.UI.Dialogs.DeployConfirmation (CanSubmitTransaction, TransactionSubmitFeedback (..),
-                                                         submitTransactionWithFeedback)
+import           Frontend.UI.Dialogs.DeployConfirmation (CanSubmitTransaction, submitTransactionWithFeedback)
 import           Frontend.UI.Modal.Impl                 (ModalIde, modalFooter)
 import           Frontend.UI.Widgets
 import           Frontend.UI.Widgets.AccountName (uiAccountNameInput)
@@ -37,12 +40,7 @@ import           Frontend.Crypto.Class                  (HasCrypto,
 import           Frontend.Crypto.Ed25519                (keyToText)
 import           Frontend.Ide                           (_ide_wallet)
 import           Frontend.JsonData
-import           Frontend.Network                       (ChainId, HasNetworkCfg,
-                                                         NodeInfo,
-                                                         defaultTransactionGasLimit,
-                                                         networkCfg_setSender,
-                                                         network_selectedNetwork,
-                                                         network_selectedNodes)
+import           Frontend.Network
 import           Frontend.Wallet                        (Account (..),
                                                          AccountName,
                                                          HasWalletCfg (..),
@@ -158,7 +156,7 @@ uiAddVanityAccountSettings ideL mChainId initialNotes = Workflow $ do
   pure
     ( ("Add New Vanity Account", (conf, never))
     , attachWith
-        (\ns res -> vanityAccountCreateSubmit dAccount (_deploymentSettingsResult_chainId res) res ns)
+        (\ns res -> vanityAccountCreateSubmit ideL dAccount (_deploymentSettingsResult_chainId res) res ns)
         (current $ ideL ^. network_selectedNodes)
         command
     )
@@ -169,30 +167,46 @@ uiAddVanityAccountSettings ideL mChainId initialNotes = Workflow $ do
 vanityAccountCreateSubmit
   :: ( Monoid mConf
      , CanSubmitTransaction t m
+     , HasNetwork model t
      , HasWalletCfg mConf key t
      )
-  => Dynamic t (Maybe (Account key))
+  => model
+  -> Dynamic t (Maybe (Account key))
   -> ChainId
   -> DeploymentSettingsResult key
   -> [Either a NodeInfo]
   -> Workflow t m (Text, (mConf, Event t ()))
-vanityAccountCreateSubmit dAccount chainId result nodeInfos = Workflow $ do
+vanityAccountCreateSubmit model dAccount chainId result nodeInfos = Workflow $ do
   let cmd = _deploymentSettingsResult_command result
 
-  txnSubFeedback <- elClass "div" "modal__main transaction_details" $
+  _txnSubFeedback <- elClass "div" "modal__main transaction_details" $
     submitTransactionWithFeedback cmd chainId nodeInfos
 
-  -- If the message has no value yet, or it is an error then disable the 'done' button to
-  -- avoid incorrectly triggering the import of the new account.
-  let isDisabled = maybe True isLeft <$> _transactionSubmitFeedback_message txnSubFeedback
+  -- Fire off a /local request and add the account if that is successful. This
+  -- is optimistic but reduces the likelyhood we create the account _without_
+  -- saving it, which is what would happen before if the user closed the dialog
+  -- without using the "Done" button. We don't check that the sender has enough
+  -- gas here, so it is possible to add non-existant accounts to the wallet.
+  -- That seems better than the alternative (spending gas to create an account
+  -- and not having access to it).
+  let req = NetworkRequest
+        { _networkRequest_cmd = cmd
+        , _networkRequest_chainRef = ChainRef Nothing chainId
+        , _networkRequest_endpoint = Endpoint_Local
+        }
+  pb <- getPostBuild
+  resp <- performLocalRead (model ^. network) $ [req] <$ pb
+  let localOk = fforMaybe resp $ \case
+        -- Generates a 'Pattern match has inaccessible right hand side' warning. Not sure why.
+        [(_, t)]
+          | Just (_, PLiteral (LString "Write succeeded")) <- justThat t
+          -> Just ()
+        _ -> Nothing
+      conf = mempty & walletCfg_importAccount .~ tagMaybe (current dAccount) localOk
 
-  eNewAccount <- modalFooter $ uiButtonDyn
-    (def & uiButtonCfg_class .~ "button_type_confirm" & uiButtonCfg_disabled .~ isDisabled)
-    (text "Done")
-
-  let cfg  = mempty & walletCfg_importAccount .~ (tagMaybe (current dAccount) eNewAccount)
+  done <- modalFooter $ confirmButton def "Done"
 
   pure
-    ( ("Creating Vanity Account", (cfg, eNewAccount))
+    ( ("Creating Vanity Account", (conf, done))
     , never
     )


### PR DESCRIPTION
Reduces the likelihood of creating accounts on chain but not having them in the wallet.

Also adds a gas check to the deployment dialog so it's less likely the above change adds accounts which don't exist on chain.