### PR TITLE
Improve error and request key display for X-Chain Transfers

### DIFF
--- a/backend/sass/common.blocks/_modal.scss
+++ b/backend/sass/common.blocks/_modal.scss
@@ -276,23 +276,6 @@
   margin-bottom: $normal-margin;
 }
 
-.cross-chain-transfer-msg {
-  margin-top: -15px;
-  height: 1.5em;
-  overflow: hidden;
-  cursor: pointer;
-  padding: 0.4em;
-  border-radius: $std-border-radius;
-
-  &.cross-chain-transfer-msg__expanded {
-    position: absolute;
-    height: auto;
-    z-index: 10;
-    background-color: #FAFAFA;
-  }
-}
-
-
 .cross-chain-transfer-retry {
   margin-top: 1em;
 }


### PR DESCRIPTION
Errors in crosschain transfers are now displayed in a box that appears below the progress
icons. The box is cleared when the transfer is re-attempted.

The request key no longer displays inline and is display when it is available in a
separate box.

Some effort has been made to pretty-print the error information.