### PR TITLE
Return correct count of capabilities when they're static

### DIFF
--- a/frontend/src/Frontend/UI/DeploymentSettings.hs
+++ b/frontend/src/Frontend/UI/DeploymentSettings.hs
@@ -961,7 +961,7 @@ uiSenderCapabilities m cid mCaps mkSender = do
           rest <- staticCapabilityRows (Just <$> eApplyToAll) $ filter (not . isGas . _dappCap_cap) caps
           pure ( _capabilityInputRow_account gas
                , combineMaps [(_capabilityInputRow_value gas),rest]
-               , constDyn 0
+               , constDyn (1 {- Gas payer -} + length caps)
                )
 
     -- If the gas capability is set, we enable the button that will set every other


### PR DESCRIPTION
The 'apply to all' will now appear correctly when capabilities are static.