### PR TITLE
Re-enable network status icon

### DIFF
--- a/backend/sass/common.blocks/_page.scss
+++ b/backend/sass/common.blocks/_page.scss
@@ -49,7 +49,3 @@
 .page__content.contracts.visible {
   display: flex;
 }
-
-.page__network-bar-select {
-  margin-left: 22px;
-}

--- a/frontend/src/Frontend/ReplGhcjs.hs
+++ b/frontend/src/Frontend/ReplGhcjs.hs
@@ -50,6 +50,7 @@ import Frontend.Foundation
 import Frontend.GistStore
 import Frontend.Ide
 import Frontend.OAuth
+import Frontend.Network
 import Frontend.Repl
 import Frontend.Storage
 import Frontend.UI.Button
@@ -58,7 +59,7 @@ import Frontend.UI.Dialogs.CreateGist (uiCreateGist)
 import Frontend.UI.Dialogs.CreatedGist (uiCreatedGist)
 import Frontend.UI.Dialogs.DeployConfirmation (uiDeployConfirmation)
 import Frontend.UI.Dialogs.LogoutConfirmation (uiLogoutConfirmation)
-import Frontend.UI.Dialogs.NetworkEdit (uiNetworkSelect)
+import Frontend.UI.Dialogs.NetworkEdit (queryNetworkStatus, uiNetworkSelect, uiNetworkStatus)
 import Frontend.UI.Dialogs.Signing (uiSigning)
 import Frontend.UI.IconGrid (IconGridCellConfig(..), iconGridLaunchLink)
 import Frontend.UI.Modal
@@ -242,8 +243,8 @@ networkBar
   -> m (ModalIdeCfg m key t)
 networkBar m = divClass "main-header main-header__network-bar" $ do
   -- Fetch and display the status of the currently selected network.
-  --queryNetworkStatus (m ^. ide_network . network_networks) (m ^. ide_network . network_selectedNetwork)
-  --  >>= uiNetworkStatus (pure " page__network-bar-status")
+  queryNetworkStatus (m ^. ide_network . network_networks) (m ^. ide_network . network_selectedNetwork)
+    >>= uiNetworkStatus (pure " page__network-bar-status")
   -- Present the dropdown box for selecting one of the configured networks.
   divClass "page__network-bar-select" $
     uiNetworkSelect (m ^. ide_network)


### PR DESCRIPTION
This simply adds the icon back and reverts the extra margin to account for the missing icon.

Sean's throttling and debouncing appear to have broken the loop. I spent some time trying to make it less laggy upon unlocking, but it turns out that mostly comes from module loading.