### PR TITLE
Remove 'userSections' field from 'DeploymentSettingsConfig

### DIFF
--- a/frontend/src/Frontend/UI/DeploymentSettings.hs
+++ b/frontend/src/Frontend/UI/DeploymentSettings.hs
@@ -397,6 +397,7 @@ uiDeploymentSettings m settings = mdo
           (_deploymentSettingsConfig_ttl settings)
           (_deploymentSettingsConfig_gasLimit settings)
           (_deploymentSettingsConfig_userSections settings)
+          (Just advancedAccordion)
 
       (mSender, signers, capabilities) <- tabPane mempty curSelection DeploymentSettingsView_Keys $
         uiSenderCapabilities m cChainId (_deploymentSettingsConfig_caps settings)
@@ -520,10 +521,6 @@ uiCfg
      , HasNetwork model t
      , HasNetworkCfg mConf t
      , Monoid mConf
-     , Flattenable mConf t
-     , HasJsonDataCfg mConf t
-     , HasWallet model key t
-     , HasJsonData model t
      , Traversable g
      )
   => Maybe (Dynamic t Text)
@@ -532,13 +529,14 @@ uiCfg
   -> Maybe TTLSeconds
   -> Maybe GasLimit
   -> g (Text, m a)
+  -> Maybe (model -> Dynamic t Bool -> m (Event t (), ((), mConf)))
   -> m ( mConf
        , Dynamic t (f Pact.ChainId)
        , Dynamic t TTLSeconds
        , Dynamic t GasLimit
        , g a
        )
-uiCfg mCode m wChainId mTTL mGasLimit userSections = do
+uiCfg mCode m wChainId mTTL mGasLimit userSections otherAccordion = do
   -- General deployment configuration
   let mkGeneralSettings = do
         traverse_ (\c -> transactionInputSection c Nothing) mCode
@@ -554,19 +552,36 @@ uiCfg mCode m wChainId mTTL mGasLimit userSections = do
 
   rec
     let mkAccordionControlDyn initActive = foldDyn (const not) initActive
-          $ leftmost [eGeneralClicked , eAdvancedClicked]
+          $ leftmost [eGeneralClicked, otherClicked]
 
     dGeneralActive <- mkAccordionControlDyn True
-    dAdvancedActive <- mkAccordionControlDyn False
 
     (eGeneralClicked, pairA) <- controlledAccordionItem dGeneralActive mempty (text "General") mkGeneralSettings
     divClass "title" blank
-    (eAdvancedClicked, pairB) <- controlledAccordionItem dAdvancedActive mempty (text "Advanced") $ do
-      -- We don't want to change focus when keyset events occur, so consume and do nothing
-      -- with the given elements and their dynamic
-      divClass "title" $ text "Data"
-      uiJsonDataSetFocus (\_ _ -> pure ()) (\_ _ -> pure ()) (m ^. wallet) (m ^. jsonData)
-  pure $ snd pairA & _1 <>~ snd pairB
+    (otherClicked, transformCfg) <- case otherAccordion of
+      Nothing -> pure (never, id)
+      Just mk -> do
+        (clk, pairB) <- mk m =<< mkAccordionControlDyn False
+        pure (clk, (_1 <>~ snd pairB))
+
+  pure $ transformCfg $ snd pairA
+
+advancedAccordion
+  :: MonadWidget t m
+  => Flattenable mConf t
+  => HasWallet model key t
+  => HasJsonData model t
+  => HasJsonDataCfg mConf t
+  => Monoid mConf
+  => model
+  -> Dynamic t Bool
+  -> m (Event t (), ((), mConf))
+advancedAccordion m active = do
+  controlledAccordionItem active mempty (text "Advanced") $ do
+    -- We don't want to change focus when keyset events occur, so consume and do nothing
+    -- with the given elements and their dynamic
+    divClass "title" $ text "Data"
+    uiJsonDataSetFocus (\_ _ -> pure ()) (\_ _ -> pure ()) (m ^. wallet) (m ^. jsonData)
 
 transactionHashSection :: MonadWidget t m => Pact.Command Text -> m ()
 transactionHashSection cmd = void $ do

--- a/frontend/src/Frontend/UI/DeploymentSettings.hs
+++ b/frontend/src/Frontend/UI/DeploymentSettings.hs
@@ -124,9 +124,6 @@ import Frontend.Wallet
 data DeploymentSettingsConfig t m model a = DeploymentSettingsConfig
   { _deploymentSettingsConfig_userTab     :: Maybe (Text, m a)
     -- ^ Some optional extra tab. fst is the tab's name, snd is its content.
-  , _deploymentSettingsConfig_userSections :: [(Text, m a)]
-    -- ^ Some optional extra input, placed between chainId selection and transaction
-    -- settings. fst is the section's name, snd is its content.
   , _deploymentSettingsConfig_chainId     :: model -> m (Dynamic t (Maybe Pact.ChainId))
     -- ^ ChainId selection widget.
     --   You can pick (predefinedChainIdSelect someId) - for not showing a
@@ -396,7 +393,7 @@ uiDeploymentSettings m settings = mdo
           (_deploymentSettingsConfig_chainId settings $ m)
           (_deploymentSettingsConfig_ttl settings)
           (_deploymentSettingsConfig_gasLimit settings)
-          (_deploymentSettingsConfig_userSections settings)
+          Nothing
           (Just advancedAccordion)
 
       (mSender, signers, capabilities) <- tabPane mempty curSelection DeploymentSettingsView_Keys $

--- a/frontend/src/Frontend/UI/Dialogs/AddVanityAccount.hs
+++ b/frontend/src/Frontend/UI/Dialogs/AddVanityAccount.hs
@@ -125,8 +125,7 @@ uiAddVanityAccountSettings ideL mChainId initialNotes = Workflow $ do
 
       let mkSettings payload = DeploymentSettingsConfig
             { _deploymentSettingsConfig_chainId = userChainIdSelect
-            , _deploymentSettingsConfig_userTab = Nothing
-            , _deploymentSettingsConfig_userSections = [uiAccSection]
+            , _deploymentSettingsConfig_userTab = Nothing :: Maybe (Text, m ())
             , _deploymentSettingsConfig_code = code
             , _deploymentSettingsConfig_sender = uiSenderDropdown def never
             , _deploymentSettingsConfig_data = payload

--- a/frontend/src/Frontend/UI/Dialogs/AddVanityAccount.hs
+++ b/frontend/src/Frontend/UI/Dialogs/AddVanityAccount.hs
@@ -106,7 +106,7 @@ uiAddVanityAccountSettings ideL mChainId initialNotes = Workflow $ do
     (conf, result, dAccount, selChain) <- elClass "div" "modal__main transaction_details" $ do
       (cfg, cChainId, ttl, gasLimit, Identity (dAccountName, dNotes)) <- tabPane mempty curSelection DeploymentSettingsView_Cfg $
         -- Is passing around 'Maybe x' everywhere really a good way of doing this ?
-        uiCfg Nothing ideL (userChainIdSelectWithPreselect ideL mChainId) Nothing (Just defaultTransactionGasLimit) (Identity uiAccSection)
+        uiCfg Nothing ideL (userChainIdSelectWithPreselect ideL mChainId) Nothing (Just defaultTransactionGasLimit) (Identity uiAccSection) Nothing
 
       (mSender, signers, capabilities) <- tabPane mempty curSelection DeploymentSettingsView_Keys $
         uiSenderCapabilities ideL cChainId Nothing $ uiSenderDropdown def never ideL cChainId

--- a/frontend/src/Frontend/UI/Dialogs/CallFunction.hs
+++ b/frontend/src/Frontend/UI/Dialogs/CallFunction.hs
@@ -78,7 +78,6 @@ uiCallFunction m mModule func _onClose
     let content = mdo
           (cfg, result, mPactCall) <- uiDeploymentSettings m $ DeploymentSettingsConfig
             { _deploymentSettingsConfig_userTab = parametersTab m func
-            , _deploymentSettingsConfig_userSections = []
             , _deploymentSettingsConfig_chainId =
                 predefinedChainIdSelect $ _chainRef_chain . _moduleRef_source $ moduleRef
             , _deploymentSettingsConfig_code = fromMaybe (pure $ buildCall func []) mPactCall

--- a/frontend/src/Frontend/UI/Dialogs/DeployConfirmation.hs
+++ b/frontend/src/Frontend/UI/Dialogs/DeployConfirmation.hs
@@ -130,7 +130,6 @@ uiDeployConfirmation code model = fullDeployFlow def model $ do
   (settingsCfg, result, _) <- uiDeploymentSettings model $ DeploymentSettingsConfig
     { _deploymentSettingsConfig_chainId = userChainIdSelect
     , _deploymentSettingsConfig_userTab = Nothing
-    , _deploymentSettingsConfig_userSections = []
     , _deploymentSettingsConfig_code = pure code
     , _deploymentSettingsConfig_sender = uiSenderDropdown def never
     , _deploymentSettingsConfig_data = Nothing

--- a/frontend/src/Frontend/UI/Dialogs/Signing.hs
+++ b/frontend/src/Frontend/UI/Dialogs/Signing.hs
@@ -59,7 +59,6 @@ uiSigning appCfg ideL signingRequest onCloseExternal = do
         Just c -> predefinedChainIdDisplayed c
         Nothing -> userChainIdSelect
     , _deploymentSettingsConfig_userTab = Nothing
-    , _deploymentSettingsConfig_userSections = []
     , _deploymentSettingsConfig_code = pure $ _signingRequest_code signingRequest
     , _deploymentSettingsConfig_sender = case _signingRequest_sender signingRequest of
         Just sender -> \_ _ -> uiSenderFixed sender


### PR DESCRIPTION
Doesn't seem to actually be used anywhere nowadays since all uses go to `uiCfg` directly.

On top of #335 because conflicts.

