### PR TITLE
Fix build of desktop derivation

### DIFF
--- a/common/common.cabal
+++ b/common/common.cabal
@@ -25,6 +25,8 @@ library
                , pact
                , split
                , bytestring
+               , tasty
+               , tasty-golden
                , template-haskell
                , megaparsec
                , safe
@@ -43,10 +45,10 @@ library
     Common.Foundation
     Common.Wallet
 
+    Common.Tests.GoldenHelper
+
 test-suite golden-tests
   type: exitcode-stdio-1.0
-
-  other-modules: GoldenHelper
 
   main-is: GoldenTests.hs
   hs-source-dirs: tests

--- a/common/src/Common/Tests/GoldenHelper.hs
+++ b/common/src/Common/Tests/GoldenHelper.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-module GoldenHelper where
+module Common.Tests.GoldenHelper where
 
 import Test.Tasty
 import Test.Tasty.Golden

--- a/common/tests/GoldenTests.hs
+++ b/common/tests/GoldenTests.hs
@@ -13,7 +13,7 @@ import Common.Wallet (AccountBalance (..), AccountName (..), UnfinishedCrossChai
 import Pact.Types.Command (RequestKey (..))
 import qualified Pact.Types.Hash as Hash
 
-import GoldenHelper
+import Common.Tests.GoldenHelper
 
 goldenTests :: [GTest]
 goldenTests =
@@ -41,4 +41,3 @@ goldenTests =
 main :: IO ()
 main = defaultMain
   $ testGroup "Golden Tests - Common" $ fmap toGoldenTest goldenTests
-

--- a/desktop/desktop.cabal
+++ b/desktop/desktop.cabal
@@ -62,8 +62,6 @@ library
 test-suite golden-tests
   type: exitcode-stdio-1.0
 
-  other-modules: GoldenHelper
-
   main-is: GoldenTests.hs
 
   ghc-options: -Wall

--- a/desktop/tests/GoldenHelper.hs
+++ b/desktop/tests/GoldenHelper.hs
@@ -1,1 +1,0 @@
-../../common/tests/GoldenHelper.hs

--- a/desktop/tests/GoldenTests.hs
+++ b/desktop/tests/GoldenTests.hs
@@ -22,7 +22,7 @@ import Pact.Types.Command (RequestKey (..))
 import qualified Pact.Types.Hash as Hash
 
 import Desktop.Frontend
-import GoldenHelper
+import Common.Tests.GoldenHelper
 
 testBIPRoot :: LBS.ByteString
 testBIPRoot = "\"020ce294062e88e49c9daa5b917384eba6175a50a229c115b5795b242b866d375b0cf1f9d477e3fdc5f277c47aa3f389ac4f13e6e58830c30e4113013eb7654de55fd721249c2c8e5188051756d9673e006d83d1e1344564efbdcbf3fcd64101188a32b7919161fb9c18650f483ee7efcd4bb684f31a5a3d9c8471f04efd0f0e\""


### PR DESCRIPTION
Even though `nix-shell --run 'cabal new-tests desktop` works, `nix-build` fails with
```
[7 of 7] Compiling Desktop          ( src/Desktop.hs, dist/build/Desktop.o )
Preprocessing test suite 'golden-tests' for desktop-0.1..
Setup: can't find source for GoldenHelper in tests,
dist/build/golden-tests/autogen, dist/build/global-autogen

builder for '/nix/store/aapwrs77asjg048zy7sk49bcfnq25c9b-desktop-0.1.drv' failed with exit code 1
error: build of '/nix/store/aapwrs77asjg048zy7sk49bcfnq25c9b-desktop-0.1.drv' failed
```
The nix derivation produced by cabal2nix doesn't seem to include the target of the `desktop/tests/GoldenHelper.hs`. 

Hopefully this is just a temporary fix. Doesn't make sense to me to throw test cases in the app per-se, but build is broken right now so this is needed for testing other things. The other option I see is extracting all the tests into `desktop` or their own package.

