### PR TITLE
Remove the chain table from the key details dialog. 

### DIFF
--- a/frontend/src/Frontend/UI/Dialogs/AccountDetails.hs
+++ b/frontend/src/Frontend/UI/Dialogs/AccountDetails.hs
@@ -90,12 +90,14 @@ uiAccountDetailsDetails netname a onClose = Workflow $ do
       -- Notes edit
       notesEdit0 :: Maybe (Dynamic t Text) <- case accountNotes a of
         -- Only vanity accounts have notes.
-        Just va -> fmap (Just . value) $ mkLabeledClsInput False "Notes" $ \cls -> uiInputElement $ def
-          & inputElementConfig_initialValue .~ unAccountNotes va
-          & initialAttributes . at "class" %~ pure . maybe (renderClass cls) (mappend (" " <> renderClass cls))
+        Just va -> do
+          notes0 <- fmap (Just . value) $ mkLabeledClsInput False "Notes" $ \cls -> uiInputElement $ def
+            & inputElementConfig_initialValue .~ unAccountNotes va
+            & initialAttributes . at "class" %~ pure . maybe (renderClass cls) (mappend (" " <> renderClass cls))
+          horizontalDashedSeparator
+          pure notes0
         _ -> pure Nothing
-      -- separator
-      horizontalDashedSeparator
+        -- separator
       -- Kadena Address
       _ <- displayText "Kadena Address" kAddr "account-details__kadena-address"
       -- copy

--- a/frontend/src/Frontend/UI/Dialogs/AccountDetails.hs
+++ b/frontend/src/Frontend/UI/Dialogs/AccountDetails.hs
@@ -94,10 +94,10 @@ uiAccountDetailsDetails netname a onClose = Workflow $ do
           notes0 <- fmap (Just . value) $ mkLabeledClsInput False "Notes" $ \cls -> uiInputElement $ def
             & inputElementConfig_initialValue .~ unAccountNotes va
             & initialAttributes . at "class" %~ pure . maybe (renderClass cls) (mappend (" " <> renderClass cls))
+          -- separator
           horizontalDashedSeparator
           pure notes0
         _ -> pure Nothing
-        -- separator
       -- Kadena Address
       _ <- displayText "Kadena Address" kAddr "account-details__kadena-address"
       -- copy

--- a/frontend/src/Frontend/UI/Dialogs/KeyDetails.hs
+++ b/frontend/src/Frontend/UI/Dialogs/KeyDetails.hs
@@ -10,45 +10,32 @@ module Frontend.UI.Dialogs.KeyDetails
 ------------------------------------------------------------------------------
 import           Control.Lens
 import           Data.Text (Text)
-import           Data.Map (Map)
-import qualified Data.Map as Map
-
-import Pact.Types.ChainId (ChainId)
-import qualified Pact.Types.ChainId as Pact
 ------------------------------------------------------------------------------
 import           Reflex
 import           Reflex.Dom hiding (Key)
 ------------------------------------------------------------------------------
-import           Frontend.Network
 import           Frontend.UI.Modal
 import           Frontend.Wallet
 import           Frontend.UI.Widgets
 import           Frontend.Foundation
 ------------------------------------------------------------------------------
 
-type HasUiKeyDetailsModelCfg model mConf key t =
+type HasUiKeyDetailsModelCfg mConf key t =
   ( Monoid mConf
   , Flattenable mConf t
   , HasWalletCfg mConf key t
-  , HasNetwork model t
-  , HasWallet model key t
   )
 
 uiKeyDetails
-  :: ( HasUiKeyDetailsModelCfg model mConf key t
+  :: ( HasUiKeyDetailsModelCfg mConf key t
      , MonadWidget t m
      )
-  => model
-  -> Key key
+  => Key key
   -> Event t ()
   -> m (mConf, Event t ())
-uiKeyDetails model key _onCloseExternal = mdo
-  let keyChainInfo = ffor2 (model ^. network_selectedNetwork) (model ^. wallet_accounts) $ \net (AccountStorage storage) -> fromMaybe mempty $ do
-        accounts <- Map.lookup net storage
-        let pk = _keyPair_publicKey $ _key_pair key
-        Map.lookup pk $ _accounts_nonVanity accounts
+uiKeyDetails key _onCloseExternal = mdo
   onClose <- modalHeader $ dynText title
-  dwf <- workflow (uiKeyDetailsDetails model key keyChainInfo onClose)
+  dwf <- workflow (uiKeyDetailsDetails key onClose)
   let (title, (conf, dEvent)) = fmap splitDynPure $ splitDynPure dwf
   mConf <- flatten =<< tagOnPostBuild conf
   return ( mConf
@@ -56,15 +43,13 @@ uiKeyDetails model key _onCloseExternal = mdo
          )
 
 uiKeyDetailsDetails
-  :: ( HasUiKeyDetailsModelCfg model mConf key t
+  :: ( HasUiKeyDetailsModelCfg mConf key t
      , MonadWidget t m
      )
-  => model
-  -> Key key
-  -> Dynamic t (Map ChainId NonVanityAccount)
+  => Key key
   -> Event t ()
   -> Workflow t m (Text, (mConf, Event t ()))
-uiKeyDetailsDetails model key keyChainInfo onClose = Workflow $ do
+uiKeyDetailsDetails key onClose = Workflow $ do
   let displayText lbl v cls =
         let
           attrFn cfg = uiInputElement $ cfg
@@ -72,84 +57,18 @@ uiKeyDetailsDetails model key keyChainInfo onClose = Workflow $ do
         in
           mkLabeledInputView False lbl attrFn $ pure v
 
-  conf <- divClass "modal__main key-details" $ do
-    _ <- divClass "group" $ do
+  divClass "modal__main key-details" $ do
+    divClass "group" $ do
       -- Public key
       _ <- displayText "Public Key" (keyToText $ _keyPair_publicKey $ _key_pair key) "key-details__pubkey"
       -- Notes
       _ <- displayText "Notes" (unAccountNotes $ _key_notes key) "key-details__notes"
       pure ()
 
-    _ <- elClass "h2" "heading heading_type_h2" $ text "Chain Specific Info"
-    divClass "group" $
-      uiChainTable model keyChainInfo
- 
   modalFooter $ do
     onDone <- confirmButton def "Done"
 
-    pure ( ("Key Details", (conf, leftmost [onClose, onDone]))
+    pure ( ("Key Details", (mempty, leftmost [onClose, onDone]))
          , never
          )
 
-uiChainTable
-  :: ( MonadFix m
-     , Monoid mConf
-     , DomBuilder t m
-     , PostBuild t m
-     , MonadHold t m
-     )
-  => model
-  -> Dynamic t (Map ChainId NonVanityAccount)
-  -> m mConf
-uiChainTable model keyChainInfo = do
-  let
-    tableAttrs =
-      "style" =: "table-layout: fixed; width: 98%"
-      <> "class" =: "key-details table"
-  _events <- elAttr "table" tableAttrs $ do
-    el "colgroup" $ do
-      elAttr "col" ("style" =: "width: 40%") blank
-      elAttr "col" ("style" =: "width: 40%") blank
-      elAttr "col" ("style" =: "width: 20%") blank
-    el "thead" $ el "tr" $ do
-      let mkHeading = elClass "th" "key-details__table-heading" . text
-      traverse_ mkHeading $
-        [ "Chain"
-        , "Balance"
-        , ""
-        ]
-
-    el "tbody" $ do
-      listWithKey keyChainInfo (uiChainTableRow model)
-
-  pure mempty
-
-tableButton :: DomBuilder t m => Text -> UiButtonCfg -> m (Event t ())
-tableButton lbl cfg = uiButton (cfg
-  & uiButtonCfg_class <>~ " key-details__table-button"
-  ) $ text lbl
-
-uiChainTableRow
-  :: ( DomBuilder t m
-     , PostBuild t m
-     )
-  => model
-  -> ChainId
-  -> Dynamic t NonVanityAccount
-  -> m (Event t ())
-uiChainTableRow _model chain dNonVanity = do
-  let
-    keyDetCls = mappend "key-details__"
-
-    burgerBtn = tableButton "TBC" $ def
-      & uiButtonCfg_class .~ "key-details__table-button--hamburger"
-
-  elClass "tr" (keyDetCls "table-row") $ do
-    let
-      td :: DomBuilder t m => m a -> m a
-      td = elClass "td" (keyDetCls "table-cell")
-
-    td $ divClass (keyDetCls "table-id") $ text $ Pact._chainId chain
-    td $ divClass (keyDetCls "table-balance") $ dynText $ fmap uiAccountBalance' dNonVanity
-    -- TODO: Wire through enough info for 'uiSendModal'
-    td $ divClass (keyDetCls "table-button") burgerBtn

--- a/frontend/src/Frontend/UI/Wallet.hs
+++ b/frontend/src/Frontend/UI/Wallet.hs
@@ -275,7 +275,7 @@ uiKeyItems model = do
     keyModal n = Just . \case
       KeyDialog_Receive name created -> uiReceiveModal model name created Nothing
       KeyDialog_Send acc -> uiSendModal model acc
-      KeyDialog_Details key -> uiKeyDetails model key
+      KeyDialog_Details key -> uiKeyDetails key
       KeyDialog_AccountDetails acc -> uiAccountDetails n acc
 
 -- | Dialogs which can be launched from keys.


### PR DESCRIPTION
Fix an issue where the horizontal separator would display incorrectly on the account details dialog.