### PR TITLE
Remove the requirement for a gas payer to be selected.

### DIFF
--- a/frontend/src/Frontend/JsonData.hs
+++ b/frontend/src/Frontend/JsonData.hs
@@ -90,7 +90,7 @@ type Keysets = Map KeysetName Keyset
 -- | User entered `_jsonData_rawInput` was invalid.
 data JsonError =
   JsonError_NoObject -- ^ Input was no valid JSON object.
-  deriving Show
+  deriving (Eq, Show)
 
 type KeysetKeys = Set PublicKey
 

--- a/frontend/src/Frontend/UI/DeploymentSettings.hs
+++ b/frontend/src/Frontend/UI/DeploymentSettings.hs
@@ -413,7 +413,7 @@ uiDeploymentSettings m settings = mdo
       (mGasPayer, signers, capabilities) <- tabPane mempty curSelection DeploymentSettingsView_Keys $ do
         dyn_ $ ffor result $ \case
           Left (DeploymentSettingsResultError_GasPayerIsNotValid _) -> divClass "group segment" $
-            text "Selected account for 'coin.GAS' capability does not exist on this network."
+            text "Selected account for 'coin.GAS' capability does not exist on this chain."
           _ ->
             blank
 

--- a/frontend/src/Frontend/UI/Dialogs/AddVanityAccount.hs
+++ b/frontend/src/Frontend/UI/Dialogs/AddVanityAccount.hs
@@ -1,20 +1,18 @@
 {-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE RecursiveDo #-}
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE TypeApplications #-}
 module Frontend.UI.Dialogs.AddVanityAccount
   ( --uiAddVanityAccountSettings
     uiAddVanityAccountButton
   ) where
 
 import           Control.Lens                           ((^.),(<>~))
+import           Control.Error                          (hush)
 import           Control.Monad.Trans.Class              (lift)
 import           Control.Monad.Trans.Maybe              (MaybeT (..), runMaybeT)
 import           Data.Functor.Identity                  (Identity(..))
 import           Data.Maybe                             (isNothing,fromMaybe)
+import           Data.Either                            (isLeft)
 import           Data.Text                              (Text)
 import           Data.Aeson                             (Object, Value (Array, String))
 import qualified Data.HashMap.Strict                    as HM
@@ -183,9 +181,9 @@ uiAddVanityAccountSettings ideL onInflightChange mInflightAcc mChainId initialNo
         , cChainId
         )
 
-    let preventProgress = (\a r -> isNothing a || isNothing r) <$> dAccount <*> result
+    let preventProgress = (\a r -> isNothing a || isLeft r) <$> dAccount <*> result
 
-    command <- performEvent $ tagMaybe (current result) eNewAccount
+    command <- performEvent $ tagMaybe (current $ fmap hush result) eNewAccount
     controls <- modalFooter $ buildDeployTabFooterControls
       customConfigTab
       includePreviewTab

--- a/frontend/src/Frontend/UI/Dialogs/AddVanityAccount.hs
+++ b/frontend/src/Frontend/UI/Dialogs/AddVanityAccount.hs
@@ -133,12 +133,20 @@ uiAddVanityAccountSettings ideL onInflightChange mInflightAcc mChainId initialNo
       _ <- widgetHold blank $ ffor onInflightChange $ \_ -> divClass "group" $
         text "The incomplete vanity account has been verified on the chain and added to your wallet. You may continue to create a new vanity account or close this dialog and start using the new account."
 
-      (cfg, cChainId, ttl, gasLimit, Identity (dAccountName, dPublicKey, dNotes)) <- tabPane mempty curSelection DeploymentSettingsView_Cfg $
+      (cfg, cChainId, mSender, ttl, gasLimit, Identity (dAccountName, dPublicKey, dNotes)) <- tabPane mempty curSelection DeploymentSettingsView_Cfg $
         -- Is passing around 'Maybe x' everywhere really a good way of doing this ?
-        uiCfg Nothing ideL (userChainIdSelectWithPreselect ideL (constDyn mChainId)) Nothing (Just defaultTransactionGasLimit) (Identity uiAccSection) Nothing
+        uiCfg
+          Nothing
+          ideL
+          (userChainIdSelectWithPreselect ideL (constDyn mChainId))
+          Nothing
+          (Just defaultTransactionGasLimit)
+          (Identity uiAccSection)
+          Nothing
+          $ uiSenderDropdown def never
 
-      (mSender, signers, capabilities) <- tabPane mempty curSelection DeploymentSettingsView_Keys $
-        uiSenderCapabilities ideL cChainId Nothing $ uiSenderDropdown def never ideL cChainId
+      (mGasPayer, signers, capabilities) <- tabPane mempty curSelection DeploymentSettingsView_Keys $
+        uiSenderCapabilities ideL cChainId Nothing mSender $ uiSenderDropdown def never ideL cChainId
 
       let dPayload = fmap mkPubkeyPactData <$> dPublicKey
           code = mkPactCode <$> dAccountName

--- a/frontend/src/Frontend/UI/Dialogs/AddVanityAccount.hs
+++ b/frontend/src/Frontend/UI/Dialogs/AddVanityAccount.hs
@@ -178,7 +178,7 @@ uiAddVanityAccountSettings ideL onInflightChange mInflightAcc mChainId initialNo
 
       pure
         ( cfg & networkCfg_setSender .~ fmapMaybe (fmap (\(Some x) -> accountRefToName x)) (updated mSender)
-        , fmap mkSettings dPayload >>= buildDeploymentSettingsResult ideL mSender signers cChainId capabilities ttl gasLimit code
+        , fmap mkSettings dPayload >>= buildDeploymentSettingsResult ideL mSender mGasPayer signers cChainId capabilities ttl gasLimit code
         , account
         , cChainId
         )

--- a/frontend/src/Frontend/UI/Widgets.hs
+++ b/frontend/src/Frontend/UI/Widgets.hs
@@ -38,6 +38,7 @@ module Frontend.UI.Widgets
   , uiInputView
   , mkLabeledInputView
   , mkLabeledInput
+  , mkLabeledView
   , uiLabeledRadioView
   , uiRadioElementView
   , mkLabeledClsInput
@@ -471,6 +472,21 @@ mkLabeledInput inlineLabel n mkInput cfg = elClass "div" ("segment segment_type_
   mkInput (cfg & initialAttributes %~ addToClassAttr "labeled-input__input")
   where
     inlineState = bool "" "-inline" inlineLabel
+
+-- | Make labeled and segmented display for some element
+--
+mkLabeledView
+  :: DomBuilder t m
+  => Bool
+  -> Text
+  -> m a
+  -> m a
+mkLabeledView inlineLabel n body = elClass "div" ("segment segment_type_tertiary labeled-input" <> inlineState) $ do
+  divClass ("label labeled-input__label" <> inlineState) $ text n
+  divClass "labeled-input__input" body
+  where
+    inlineState = bool "" "-inline" inlineLabel
+
 -- | Make some input a labeled input.
 --
 --   Any widget creating function that can be called with additional classes will do.


### PR DESCRIPTION
Add the "transaction sender" field to the transaction configuration pane and replace the uses of gas payer.

If a gas payer is selected then the their balance is checked and the transaction will fail if they have insufficient gas.

Added a notice that is displayed on the preview tab that advises the user that no gas payer has been selected.