### PR TITLE
Redo public key truncation

### DIFF
--- a/frontend/src/Frontend/UI/Wallet.hs
+++ b/frontend/src/Frontend/UI/Wallet.hs
@@ -241,8 +241,8 @@ uiKeyItems model = do
   events <- elAttr "table" tableAttrs $ do
     el "colgroup" $ do
       elAttr "col" ("style" =: "width: 5%") blank
-      elAttr "col" ("style" =: "width: 35%") blank
       elAttr "col" ("style" =: "width: 20%") blank
+      elAttr "col" ("style" =: "width: 35%") blank
       elAttr "col" ("style" =: "width: 20%") blank
       elAttr "col" ("style" =: "width: 20%") blank
     el "thead" $ el "tr" $ do
@@ -323,7 +323,7 @@ uiKeyItem model keyIndex key = do
       keyRow open balance = trKey $ do
         let accordionCell o = "wallet__table-cell" <> if o then "" else " accordion-collapsed"
         clk <- elDynClass "td" (accordionCell <$> open) $ accordionButton def
-        td $ dynText $ keyToText . _keyPair_publicKey . _key_pair <$> key
+        td $ dynText $ uiPublicKeyShrunk . _keyPair_publicKey . _key_pair <$> key
         td $ dynText $ unAccountNotes . _key_notes <$> key
         td $ dynText $ uiAccountBalance False . Just <$> balance
         dialog <- td $ buttons $ do

--- a/frontend/src/Frontend/UI/Widgets.hs
+++ b/frontend/src/Frontend/UI/Widgets.hs
@@ -51,6 +51,7 @@ module Frontend.UI.Widgets
   , uiAccountBalance'
   , uiAccountChain
   , uiAccountNotes
+  , uiPublicKeyShrunk
     -- ** Helper widgets
   , imgWithAlt
   , showLoading
@@ -585,6 +586,11 @@ uiAccountChain = _chainId . accountChain
 
 uiAccountNotes :: Account -> Text
 uiAccountNotes = maybe "" unAccountNotes . accountNotes
+
+uiPublicKeyShrunk :: PublicKey -> Text
+uiPublicKeyShrunk pk = (T.take 6 ktxt) <> "..." <> (T.drop (T.length ktxt - 6) ktxt)
+  where
+    ktxt = keyToText pk
 
 showLoading
   :: (NotReady t m, Adjustable t m, PostBuild t m, DomBuilder t m, Monoid b)

--- a/frontend/src/Frontend/UI/Widgets.hs
+++ b/frontend/src/Frontend/UI/Widgets.hs
@@ -588,7 +588,7 @@ uiAccountNotes :: Account -> Text
 uiAccountNotes = maybe "" unAccountNotes . accountNotes
 
 uiPublicKeyShrunk :: PublicKey -> Text
-uiPublicKeyShrunk pk = (T.take 6 ktxt) <> "..." <> (T.drop (T.length ktxt - 6) ktxt)
+uiPublicKeyShrunk pk = (T.take 6 ktxt) <> "..." <> (T.takeEnd 6 ktxt)
   where
     ktxt = keyToText pk
 


### PR DESCRIPTION
New format is the first 6 characters, `...`, then the last 6 characters of the public key.

Added function in `Widgets` for when it is needed else where.