### PR TITLE
Prevent network header from flexing

### DIFF
--- a/backend/sass/common.blocks/_main-header.scss
+++ b/backend/sass/common.blocks/_main-header.scss
@@ -27,6 +27,7 @@ $main-header-wallet-btn-bg: #ececec;
   padding-top: $normal-padding;
   padding-bottom: $normal-padding;
   position: relative;
+  flex: none;
 }
 
 .main-header__page-name {


### PR DESCRIPTION
Tiny fix to stop the top bar from squashing on the keys page