### PR TITLE
Replace capabilities on account creation with only gas payer dropdown.

### DIFF
--- a/frontend/src/Frontend/UI/Dialogs/Send.hs
+++ b/frontend/src/Frontend/UI/Dialogs/Send.hs
@@ -304,10 +304,6 @@ sendConfig model fromAccount = Workflow $ do
           Right (ka, _amount) -> do
             let toChain = _kadenaAddress_chainId ka
                 fromChain = accountChain fromAccount
-                uiGasPayerDropdown gasAcc = ffor3 (model ^. wallet_accounts) (model ^. network_selectedNetwork) gasAcc $ \netToAccount net ma -> do
-                  accounts <- Map.lookup net $ unAccountStorage netToAccount
-                  a <- ma
-                  lookupAccountRef a accounts
             when (toChain /= fromChain) $ do
               elClass "h3" ("heading heading_type_h3") $ text "This is a cross chain transfer."
               el "p" $ text $ T.concat
@@ -329,7 +325,7 @@ sendConfig model fromAccount = Workflow $ do
               let cfg = def & dropdownConfig_attributes .~ pure ("class" =: "labeled-input__input")
                   chain = pure $ Just fromChain
               gasAcc <- uiSenderDropdown cfg never model chain
-              pure $ uiGasPayerDropdown gasAcc
+              pure $ lookupAccountFromRef model gasAcc
             toGasPayer <- if toChain == fromChain
               then pure $ pure $ Just Nothing
               else do
@@ -342,7 +338,7 @@ sendConfig model fromAccount = Workflow $ do
                   let cfg = def & dropdownConfig_attributes .~ pure ("class" =: "labeled-input__input")
                       chain = pure $ Just toChain
                   gasAcc <- uiSenderDropdown cfg never model chain
-                  pure $ fmap Just $ uiGasPayerDropdown gasAcc
+                  pure $ Just <$> lookupAccountFromRef model gasAcc
             pure $ (liftA2 . liftA2) (,) fromGasPayer toGasPayer
       pure (conf, mCaps, recipient)
     footerSection currentTab recipient mCaps = modalFooter $ do

--- a/frontend/src/Frontend/Wallet.hs
+++ b/frontend/src/Frontend/Wallet.hs
@@ -40,6 +40,7 @@ module Frontend.Wallet
   , snocIntMap
   , findNextKey
   , findFirstVanityAccount
+  , lookupAccountFromRef
   , getSigningPairs
   , module Common.Wallet
   ) where
@@ -145,6 +146,23 @@ nextKey = maybe 0 (succ . fst) . IntMap.lookupMax
 
 findNextKey :: Reflex t => Wallet key t -> Dynamic t Int
 findNextKey = fmap nextKey . _wallet_keys
+
+lookupAccountFromRef
+  :: ( HasWallet model key t
+     , HasNetwork model t
+     , Applicative (Dynamic t)
+     )
+  => model
+  -> Dynamic t (Maybe (Some AccountRef))
+  -> Dynamic t (Maybe Account)
+lookupAccountFromRef model mAccRef = ffor3
+  (model ^. wallet_accounts)
+  (model ^. network_selectedNetwork)
+  mAccRef
+  $ \netToAccount net ma -> do
+      accounts <- Map.lookup net $ unAccountStorage netToAccount
+      a <- ma
+      lookupAccountRef a accounts
 
 -- | Make a functional wallet that can contain actual keys.
 makeWallet


### PR DESCRIPTION
Now matches the 'Sign' tab of the 'Send' dialog workflow.