### PR TITLE
Add inline error reporting widget.

### DIFF
--- a/backend/sass/common.blocks/_input.scss
+++ b/backend/sass/common.blocks/_input.scss
@@ -125,17 +125,6 @@ input[type=number] {
   }
 }
 
-.dimensional-input-wrapper {
-  display: flex;
-  position: relative;
-  align-items: center;
-  width: 100%;
-
-  input {
-    padding-left: 90px;
-  }
-}
-
 .dimensional-input-wrapper__units {
   pointer-events: none;
   position: absolute;
@@ -143,8 +132,21 @@ input[type=number] {
   color: $tertiary-color;
 }
 
-.real-input__rounded {
+.dimensional-input-wrapper {
+  display: flex;
+  position: relative;
+  align-items: center;
+  width: 100%;
+
+  .dimensional-input-wrapper__units + input {
+    padding-left: 90px;
+  }
+}
+
+.dimensional-input__feedback {
   position: absolute;
   right: 10px;
   color: $tertiary-color;
+  background: white;
+  padding-left: 0.5rem;
 }

--- a/backend/sass/common.blocks/_modal.scss
+++ b/backend/sass/common.blocks/_modal.scss
@@ -305,6 +305,3 @@ body[data-modal-open='true'] {
   margin-bottom: 50px;
 }
 
-.vanity-account-create__account-name-error {
-  min-height: 20px;
-}

--- a/frontend/src/Frontend/UI/DeploymentSettings.hs
+++ b/frontend/src/Frontend/UI/DeploymentSettings.hs
@@ -653,7 +653,7 @@ uiMetaData m mTTL mGasLimit = do
       mkGasLimitInput
         :: InputElementConfig EventResult t (DomBuilderSpace m)
         -> m (Event t Integer)
-      mkGasLimitInput conf = inlineInputFeedbackWrapper (Just "Units") $ fmap snd $ uiIntInputElement (Just 0) (Just chainwebGasLimitMaximum) $ conf
+      mkGasLimitInput conf = dimensionalInputFeedbackWrapper (Just "Units") $ fmap snd $ uiIntInputElement (Just 0) (Just chainwebGasLimitMaximum) $ conf
         & inputElementConfig_initialValue .~ showGasLimit initGasLimit
         & inputElementConfig_setValue .~ fmap showGasLimit pbGasLimit
         & inputElementConfig_elementConfig . elementConfig_eventSpec %~ preventScrollWheelAndUpDownArrow @m
@@ -685,7 +685,7 @@ uiMetaData m mTTL mGasLimit = do
                 & inputElementConfig_initialValue .~ showTtl initTTL
           sliderEl <- uiSlider "" (text $ prettyTTL minTTL) (text "1 day") $ conf
             & inputElementConfig_setValue .~ _inputElement_input inputEl
-          (inputEl, inputEv) <- inlineInputFeedbackWrapper (Just "Seconds") $ uiIntInputElement (Just minTTL) (Just secondsInDay) $ conf
+          (inputEl, inputEv) <- dimensionalInputFeedbackWrapper (Just "Seconds") $ uiIntInputElement (Just minTTL) (Just secondsInDay) $ conf
             & inputElementConfig_setValue .~ _inputElement_input sliderEl
           pure $ leftmost
             [ TTLSeconds . ParsedInteger <$> inputEv

--- a/frontend/src/Frontend/UI/DeploymentSettings.hs
+++ b/frontend/src/Frontend/UI/DeploymentSettings.hs
@@ -653,7 +653,7 @@ uiMetaData m mTTL mGasLimit = do
       mkGasLimitInput
         :: InputElementConfig EventResult t (DomBuilderSpace m)
         -> m (Event t Integer)
-      mkGasLimitInput conf = dimensionalInputWrapper "Units" $ fmap snd $ uiIntInputElement (Just 0) (Just chainwebGasLimitMaximum) $ conf
+      mkGasLimitInput conf = inlineInputFeedbackWrapper (Just "Units") $ fmap snd $ uiIntInputElement (Just 0) (Just chainwebGasLimitMaximum) $ conf
         & inputElementConfig_initialValue .~ showGasLimit initGasLimit
         & inputElementConfig_setValue .~ fmap showGasLimit pbGasLimit
         & inputElementConfig_elementConfig . elementConfig_eventSpec %~ preventScrollWheelAndUpDownArrow @m
@@ -685,7 +685,7 @@ uiMetaData m mTTL mGasLimit = do
                 & inputElementConfig_initialValue .~ showTtl initTTL
           sliderEl <- uiSlider "" (text $ prettyTTL minTTL) (text "1 day") $ conf
             & inputElementConfig_setValue .~ _inputElement_input inputEl
-          (inputEl, inputEv) <- dimensionalInputWrapper "Seconds" $ uiIntInputElement (Just minTTL) (Just secondsInDay) $ conf
+          (inputEl, inputEv) <- inlineInputFeedbackWrapper (Just "Seconds") $ uiIntInputElement (Just minTTL) (Just secondsInDay) $ conf
             & inputElementConfig_setValue .~ _inputElement_input sliderEl
           pure $ leftmost
             [ TTLSeconds . ParsedInteger <$> inputEv

--- a/frontend/src/Frontend/UI/Dialogs/Receive.hs
+++ b/frontend/src/Frontend/UI/Dialogs/Receive.hs
@@ -74,8 +74,7 @@ uiReceiveFromLegacyAccount
 uiReceiveFromLegacyAccount model = do
   mAccountName <- uiAccountNameInput model (pure Nothing) Nothing
 
-  onKeyPair <- divClass "account-details__private-key" $
-    _inputElement_input <$> mkLabeledInput True "Private Key" uiInputElement def
+  onKeyPair <-  _inputElement_input <$> mkLabeledInput True "Private Key" uiInputElement def
 
   (deriveErr, okPair) <- fmap fanEither . performEvent $ deriveKeyPair <$> onKeyPair
 

--- a/frontend/src/Frontend/UI/Dialogs/Send.hs
+++ b/frontend/src/Frontend/UI/Dialogs/Send.hs
@@ -74,7 +74,7 @@ import Frontend.UI.Dialogs.DeployConfirmation (submitTransactionWithFeedback)
 import Frontend.UI.Modal
 import Frontend.UI.TabBar
 import Frontend.UI.Widgets
-import Frontend.UI.Widgets.Helpers (dialogSectionHeading)
+import Frontend.UI.Widgets.Helpers (inputIsDirty, dialogSectionHeading)
 import Frontend.Wallet
 
 -- | A modal for handling sending coin
@@ -294,7 +294,7 @@ sendConfig model fromAccount = Workflow $ do
 
           decoded <- fmap snd $ mkLabeledInput True "Kadena Address" (uiInputWithInlineFeedback
             (fmap decodeKadenaAddressText . value)
-            (fmap (not . T.null) . value)
+            inputIsDirty
             prettyKadenaAddrErrors
             Nothing
             uiInputElement

--- a/frontend/src/Frontend/UI/Widgets.hs
+++ b/frontend/src/Frontend/UI/Widgets.hs
@@ -25,6 +25,7 @@ module Frontend.UI.Widgets
   , userChainIdSelectWithPreselect
   , uiChainSelection
   -- ** Other widgets
+  , uiInputWithInlineFeedback
   , uiSegment
   , uiGroup
   , uiGroupHeader
@@ -72,7 +73,7 @@ module Frontend.UI.Widgets
   , noAutofillAttrs
   , addNoAutofillAttrs
   , horizontalDashedSeparator
-  , dimensionalInputWrapper
+  , inlineInputFeedbackWrapper
   , uiSidebarIcon
   ) where
 
@@ -288,6 +289,33 @@ uiCorrectingInputElement parse inputSanitize blurSanitize render cfg = mdo
 
   pure (ie, (fmap . fmap) fst $ inputSanitization val, inp')
 
+uiInputWithInlineFeedback
+  :: ( DomBuilder t m
+     , PostBuild t m
+     , MonadHold t m
+     , MonadFix m 
+     )
+  => (a -> Dynamic t (Either e b))
+  -> (a -> Dynamic t Bool)
+  -> (e -> Text)
+  -> Maybe Text
+  -> (InputElementConfig EventResult t (DomBuilderSpace m) -> m a)
+  -> InputElementConfig EventResult t (DomBuilderSpace m)
+  -> m (a, Dynamic t (Either e b))
+uiInputWithInlineFeedback parse isEmpty renderFeedback mUnits mkInp cfg =
+  inlineInputFeedbackWrapper mUnits $ do
+    inp <- mkInp cfg
+
+    let parsed = parse inp
+
+    dFieldDirty <- holdUniqDyn $ isEmpty inp
+
+    dyn_ $ ffor2 parsed dFieldDirty $ curry $ \case
+      (Left e, True) ->  elClass "span" "dimensional-input__feedback" $ text $ renderFeedback e
+      _ -> blank
+
+    pure (inp, parsed)
+  
 -- | Decimal input to the given precision. Returns the element, the value, and
 -- the user input events
 uiNonnegativeRealWithPrecisionInputElement
@@ -302,7 +330,8 @@ uiNonnegativeRealWithPrecisionInputElement prec fromDecimal cfg = do
       & initialAttributes %~ addInputElementCls . addNoAutofillAttrs
         . (<> ("type" =: "number" <> "step" =: stepSize <> "min" =: stepSize))
     widgetHold_ blank $ ffor (fmap snd input) $ traverse_ $
-      elClass "span" "real-input__rounded" . text
+      elClass "span" "dimensional-input__feedback" . text
+
   pure (ie, (fmap . fmap) fromDecimal val, fmap (fromDecimal . fst) input)
 
   where
@@ -701,9 +730,9 @@ paginationWidget cls currentPage totalPages = elKlass "div" (cls <> "pagination"
 horizontalDashedSeparator :: DomBuilder t m => m ()
 horizontalDashedSeparator = divClass "horizontal-dashed-separator" blank
 
-dimensionalInputWrapper :: DomBuilder t m => Text -> m a -> m a
-dimensionalInputWrapper units inp = divClass "dimensional-input-wrapper" $ do
-  divClass "dimensional-input-wrapper__units" $ text units
+inlineInputFeedbackWrapper ::  DomBuilder t m => Maybe Text -> m a -> m a
+inlineInputFeedbackWrapper units inp = divClass "dimensional-input-wrapper" $ do
+  traverse_ (divClass "dimensional-input-wrapper__units" . text) units
   inp
 
 uiDetailsCopyButton
@@ -747,7 +776,7 @@ uiGasPriceInputField
        , Dynamic t (Maybe GasPrice)
        , Event t GasPrice
        )
-uiGasPriceInputField conf = dimensionalInputWrapper "KDA" $
+uiGasPriceInputField conf = inlineInputFeedbackWrapper (Just "KDA") $
  uiNonnegativeRealWithPrecisionInputElement maxCoinPrecision (GasPrice . ParsedDecimal) $ conf
   & initialAttributes %~ addToClassAttr "input-units"
   & inputElementConfig_elementConfig . elementConfig_eventSpec %~ preventScrollWheelAndUpDownArrow @m

--- a/frontend/src/Frontend/UI/Widgets/AccountName.hs
+++ b/frontend/src/Frontend/UI/Widgets/AccountName.hs
@@ -4,20 +4,20 @@ module Frontend.UI.Widgets.AccountName
 
 import Control.Error (hush)
 import Control.Monad.Fix (MonadFix)
-import qualified Data.Text as Text
 import Pact.Types.ChainId
 import Data.Foldable (fold)
 import Reflex
 import Reflex.Dom
 
 import Frontend.UI.Widgets (mkLabeledInput, uiInputElement, uiInputWithInlineFeedback)
+import Frontend.UI.Widgets.Helpers (inputIsDirty)
 import Frontend.Network (HasNetwork)
 import Frontend.Wallet (AccountName(..), checkAccountNameValidity, HasWallet)
 
 uiAccountNameInput
   :: ( DomBuilder t m
-     , PostBuild t m
      , MonadHold t m
+     , PostBuild t m
      , MonadFix m
      , HasWallet model key t
      , HasNetwork model t
@@ -34,7 +34,7 @@ uiAccountNameInput w mChain initval = do
 
     inputWithFeedback = uiInputWithInlineFeedback
       validateAccountName
-      (fmap (not . Text.null) . value)
+      inputIsDirty
       id
       Nothing
       uiInputElement

--- a/frontend/src/Frontend/UI/Widgets/AccountName.hs
+++ b/frontend/src/Frontend/UI/Widgets/AccountName.hs
@@ -10,8 +10,7 @@ import Data.Foldable (fold)
 import Reflex
 import Reflex.Dom
 
-import Frontend.Foundation (renderClass)
-import Frontend.UI.Widgets (mkLabeledClsInput, uiInputElement, mkLabeledView)
+import Frontend.UI.Widgets (mkLabeledInput, uiInputElement, uiInputWithInlineFeedback)
 import Frontend.Network (HasNetwork)
 import Frontend.Wallet (AccountName(..), checkAccountNameValidity, HasWallet)
 
@@ -29,23 +28,18 @@ uiAccountNameInput
   -> m (Dynamic t (Maybe AccountName))
 uiAccountNameInput w mChain initval = do
   let
-    validateAccountName = ($) <$> checkAccountNameValidity w <*> mChain
+    validateAccountName v = checkAccountNameValidity w
+      <*> mChain
+      <*> value v
 
-    inp lbl wrapperCls = divClass wrapperCls $ mkLabeledClsInput True lbl
-      $ \cls -> uiInputElement $ def
-        & initialAttributes .~ "class" =: (renderClass cls)
-        & inputElementConfig_initialValue .~ fold (fmap unAccountName initval)
+    inputWithFeedback = uiInputWithInlineFeedback
+      validateAccountName
+      (fmap (not . Text.null) . value)
+      id
+      Nothing
+      uiInputElement
 
-  divClass "vanity-account-create__account-name" $ do
-    dValue <- value <$> inp "Account Name" "vanity-account-create__account-name-input"
+  (_, dEitherAccName) <- mkLabeledInput True "Account Name" inputWithFeedback $ def
+    & inputElementConfig_initialValue .~ fold (fmap unAccountName initval)
 
-    let dEitherAccName = validateAccountName <*> dValue
-
-    dAccNameDirty <- holdUniqDyn $ not . Text.null <$> dValue
-
-    divClass "vanity-account-create__account-name-error" $ mkLabeledView True Text.empty $
-      dyn_ $ ffor2 dAccNameDirty dEitherAccName $ curry $ \case
-        (True, Left e) -> text e
-        _ -> blank
-
-    pure $ hush <$> dEitherAccName
+  pure $ hush <$> dEitherAccName

--- a/frontend/src/Frontend/UI/Widgets/Helpers.hs
+++ b/frontend/src/Frontend/UI/Widgets/Helpers.hs
@@ -16,6 +16,7 @@ module Frontend.UI.Widgets.Helpers
   , setFocusOnSelected
   , preventScrollWheelAndUpDownArrow
   , dialogSectionHeading
+  , inputIsDirty
   ) where
 
 ------------------------------------------------------------------------------
@@ -24,6 +25,7 @@ import           Control.Monad
 import           Data.Proxy                  (Proxy (..))
 import           Data.Map.Strict             (Map)
 import           Data.Text                   (Text)
+import qualified Data.Text                   as Text
 import           Language.Javascript.JSaddle (PToJSVal, call, eval, js0, obj,
                                               pToJSVal)
 import qualified Web.KeyCode                 as Keys
@@ -33,6 +35,8 @@ import           Reflex.Dom.Core
 import           Frontend.Foundation
 ------------------------------------------------------------------------------
 
+inputIsDirty :: Reflex t => InputElement er d t -> Dynamic t Bool
+inputIsDirty = fmap (not . Text.null) . value
 
 imgWithAlt :: DomBuilder t m => Text -> Text -> m a -> m a
 imgWithAlt = imgWithAltCls mempty


### PR DESCRIPTION
Created widget that does some error capturing and reports the given feedback inline in the
input element.

Adjusted affected fields.

Rebuilt the kadena address and account name inputs to use the new widget. Removed
adjustments that made those fields sit at a different spacing to other fields.

Added spacing to the Private Key field on the Receive dialog so it now matches other fields.