### PR TITLE
Limit notes field to 70 characters.

### DIFF
--- a/frontend/src/Frontend/UI/Dialogs/AccountDetails.hs
+++ b/frontend/src/Frontend/UI/Dialogs/AccountDetails.hs
@@ -93,6 +93,7 @@ uiAccountDetailsDetails netname a onClose = Workflow $ do
           notes0 <- fmap (Just . value) $ mkLabeledClsInput False "Notes" $ \cls -> uiInputElement $ def
             & inputElementConfig_initialValue .~ unAccountNotes va
             & initialAttributes . at "class" %~ pure . maybe (renderClass cls) (mappend (" " <> renderClass cls))
+            & initialAttributes <>~ "maxlength" =: "70"
           -- separator
           horizontalDashedSeparator
           pure notes0

--- a/frontend/src/Frontend/UI/Dialogs/AddVanityAccount.hs
+++ b/frontend/src/Frontend/UI/Dialogs/AddVanityAccount.hs
@@ -113,7 +113,10 @@ uiAddVanityAccountSettings ideL onInflightChange mInflightAcc mChainId initialNo
 
     notesInput initCfg = divClass "vanity-account-create__notes" $ mkLabeledClsInput True "Notes"
       $ \cls -> uiInputElement $ initCfg
-          & initialAttributes <>~ "class" =: (renderClass cls)
+          & initialAttributes <>~ (
+            "class" =: (renderClass cls) <>
+            "maxlength" =: "70"
+          )
           & inputElementConfig_initialValue .~ fromMaybe initialNotes (fmap (getNotes . snd) mInflightAcc)
 
   let includePreviewTab = False

--- a/frontend/src/Frontend/UI/Dialogs/KeyDetails.hs
+++ b/frontend/src/Frontend/UI/Dialogs/KeyDetails.hs
@@ -83,6 +83,7 @@ uiKeyDetailsDetails keyIndex key onClose onCloseExternal = Workflow $ do
       notes <- fmap value $ mkLabeledClsInput False "Notes" $ \cls -> uiInputElement $ def
         & inputElementConfig_initialValue .~ unAccountNotes (_key_notes key)
         & initialAttributes . at "class" %~ pure . maybe (renderClass cls) (mappend (" " <> renderClass cls))
+        & initialAttributes <>~ "maxlength" =: "70"
 
       void $ accordionItemWithClick False mempty (accordionHeaderBtn "Advanced") $ withSecretKey $ \pk -> do
         txt <- fmap value $ mkLabeledClsInput False "Data to sign (Base64Url Unpadded)" $ \cls -> uiTextAreaElement $ def


### PR DESCRIPTION
Given we'll have notes in the wild, wasn't sure about applying the restriction at the level of the `AccountNotes` type?