### PR TITLE
Limit display of home button for Module Explorer

### DIFF
--- a/frontend/src/Frontend/UI/ModuleExplorer/ModuleDetails.hs
+++ b/frontend/src/Frontend/UI/ModuleExplorer/ModuleDetails.hs
@@ -74,10 +74,20 @@ moduleDetails
   -> (ModuleRef, ModuleDef (Term Name))
   -> m mConf
 moduleDetails m (selectedRef, selected) = do
+    currentStackSize <- fmap length $ sample $ current $ m ^. moduleExplorer_moduleStack
+
     headerCfg <- elClass "div" "segment" $ do
       ((onHome, onBack), onLoad) <- elClass "h2" "heading heading_type_h2" $ do
-        hb <- el "div" $
-          (,) <$> homeButton "heading__left-double-button" <*> backButton
+        hb <- el "div" $ do
+          onHome <- if currentStackSize <= 1 then
+              pure never
+            else
+              homeButton "heading__left-double-button"
+
+          onBack <- backButton
+          pure (onHome, onBack)
+
+          -- (,) <$> homeButton "heading__left-double-button" <*> backButton
         (hb,) <$> openButton mempty
 
       moduleTitle

--- a/frontend/src/Frontend/UI/ModuleExplorer/ModuleDetails.hs
+++ b/frontend/src/Frontend/UI/ModuleExplorer/ModuleDetails.hs
@@ -87,7 +87,6 @@ moduleDetails m (selectedRef, selected) = do
           onBack <- backButton
           pure (onHome, onBack)
 
-          -- (,) <$> homeButton "heading__left-double-button" <*> backButton
         (hb,) <$> openButton mempty
 
       moduleTitle

--- a/frontend/src/Frontend/UI/ModuleExplorer/ModuleDetails.hs
+++ b/frontend/src/Frontend/UI/ModuleExplorer/ModuleDetails.hs
@@ -22,6 +22,7 @@
 module Frontend.UI.ModuleExplorer.ModuleDetails where
 
 ------------------------------------------------------------------------------
+import           Control.Monad                         ((<=<))
 import           Control.Lens
 import           Data.Bool                             (bool)
 import           Data.Maybe
@@ -74,12 +75,11 @@ moduleDetails
   -> (ModuleRef, ModuleDef (Term Name))
   -> m mConf
 moduleDetails m (selectedRef, selected) = do
-    currentStackSize <- fmap length $ sample $ current $ m ^. moduleExplorer_moduleStack
-
     headerCfg <- elClass "div" "segment" $ do
       ((onHome, onBack), onLoad) <- elClass "h2" "heading heading_type_h2" $ do
         hb <- el "div" $ do
-          onHome <- if currentStackSize <= 1 then
+          onHome <- switchHold never <=< dyn $ ffor (m ^. moduleExplorer_moduleStack) $ \ms ->
+            if length ms <= 1 then
               pure never
             else
               homeButton "heading__left-double-button"


### PR DESCRIPTION
Only show the home button in the module explorer when the current module
is not the top of the stack.