### PR TITLE
Fix: chainweaver blue scrollbars everywhere

### DIFF
--- a/backend/sass/_scrollbars.scss
+++ b/backend/sass/_scrollbars.scss
@@ -1,18 +1,18 @@
 $thumbBG: $chainweaver-blue;
 $scrollbarBG: $white;
 
-body::-webkit-scrollbar {
-  width: 18px;
-  height: 18px;
-}
-body {
+* {
   scrollbar-width: thin;
   scrollbar-color: $thumbBG $scrollbarBG;
 }
-body::-webkit-scrollbar-track {
+*::-webkit-scrollbar {
+  width: 18px;
+  height: 18px;
+}
+*::-webkit-scrollbar-track {
   background: $scrollbarBG;
 }
-body::-webkit-scrollbar-thumb {
+*::-webkit-scrollbar-thumb {
   background-color: $thumbBG;
   border-radius: 6px;
   border: 3px solid $scrollbarBG;

--- a/linux.nix
+++ b/linux.nix
@@ -3,7 +3,7 @@
 , appName
 , sass
 , linuxAppName ? "kadena-chainweaver"
-, linuxPackageVersion ? "0.1.0-2"
+, linuxPackageVersion ? "0.1.0-3"
 , linuxAppIcon ? ./linux/static/icons/pact-document.png
 }: rec {
   # If we don't wrapGApps, none of the gnome schema stuff works in nixos


### PR DESCRIPTION
Some of the scrollbars in dialogs and what not were still system defaults, which in default ubuntu is a very out of place orange.This takes the body scrollbar styling and puts it everywhere. 