### PR TITLE
Passthru scroll events in number inputs

### DIFF
--- a/frontend/src/Frontend/UI/DeploymentSettings.hs
+++ b/frontend/src/Frontend/UI/DeploymentSettings.hs
@@ -113,7 +113,7 @@ import Frontend.UI.JsonData
 import Frontend.UI.Modal
 import Frontend.UI.TabBar
 import Frontend.UI.Widgets
-import Frontend.UI.Widgets.Helpers (preventScrollWheelAndUpDownArrow,dialogSectionHeading)
+import Frontend.UI.Widgets.Helpers (preventUpAndDownArrow, preventScrollWheel, dialogSectionHeading)
 import Frontend.Wallet
 
 -- | Config for the deployment settings widget.
@@ -610,6 +610,7 @@ uiMetaData
   :: forall t m model mConf
      . ( DomBuilder t m, MonadHold t m, MonadFix m, PostBuild t m
        , HasNetwork model t, HasNetworkCfg mConf t, Monoid mConf
+       , GhcjsDomSpace ~ DomBuilderSpace m, MonadJSM m
        )
   => model -> Maybe TTLSeconds -> Maybe GasLimit -> m (mConf, Dynamic t TTLSeconds, Dynamic t GasLimit)
 uiMetaData m mTTL mGasLimit = do
@@ -653,10 +654,13 @@ uiMetaData m mTTL mGasLimit = do
       mkGasLimitInput
         :: InputElementConfig EventResult t (DomBuilderSpace m)
         -> m (Event t Integer)
-      mkGasLimitInput conf = dimensionalInputFeedbackWrapper (Just "Units") $ fmap snd $ uiIntInputElement (Just 0) (Just chainwebGasLimitMaximum) $ conf
-        & inputElementConfig_initialValue .~ showGasLimit initGasLimit
-        & inputElementConfig_setValue .~ fmap showGasLimit pbGasLimit
-        & inputElementConfig_elementConfig . elementConfig_eventSpec %~ preventScrollWheelAndUpDownArrow @m
+      mkGasLimitInput conf = dimensionalInputFeedbackWrapper (Just "Units") $ do
+        (i, e) <- uiIntInputElement (Just 0) (Just chainwebGasLimitMaximum) $ conf
+          & inputElementConfig_initialValue .~ showGasLimit initGasLimit
+          & inputElementConfig_setValue .~ fmap showGasLimit pbGasLimit
+          & inputElementConfig_elementConfig . elementConfig_eventSpec %~ preventUpAndDownArrow @m
+        preventScrollWheel $ _inputElement_raw i
+        pure e
 
     onGasLimit <- (fmap . fmap) (GasLimit . ParsedInteger) $ mkLabeledInput True "Gas Limit" mkGasLimitInput def
 

--- a/frontend/src/Frontend/UI/Dialogs/Send.hs
+++ b/frontend/src/Frontend/UI/Dialogs/Send.hs
@@ -486,6 +486,7 @@ runUnfinishedCrossChainTransfer logL netInfo keys fromChain toChain toGasPayer r
 -- transfer.
 finishCrossChainTransferConfig
   :: ( PerformEvent t m, PostBuild t m, TriggerEvent t m, MonadHold t m, DomBuilder t m
+     , GhcjsDomSpace ~ DomBuilderSpace m, MonadJSM m
      , MonadJSM (Performable m), MonadFix m
      , HasCrypto key (Performable m)
      , Monoid mConf, HasWalletCfg mConf key t

--- a/frontend/src/Frontend/UI/Widgets.hs
+++ b/frontend/src/Frontend/UI/Widgets.hs
@@ -110,7 +110,8 @@ import           Frontend.UI.Button
 import           Frontend.UI.Widgets.Helpers (imgWithAlt, imgWithAltCls, makeClickable,
                                               setFocus, setFocusOn,
                                               setFocusOnSelected, tabPane,
-                                              preventScrollWheelAndUpDownArrow,
+                                              preventUpAndDownArrow,
+                                              preventScrollWheel,
                                               tabPane')
 import           Frontend.KadenaAddress (textKadenaAddress, KadenaAddress)
 ------------------------------------------------------------------------------
@@ -769,16 +770,20 @@ uiGasPriceInputField
      ( DomBuilder t m
      , MonadFix m
      , MonadHold t m
+     , GhcjsDomSpace ~ DomBuilderSpace m
+     , MonadJSM m
      )
   => InputElementConfig EventResult t (DomBuilderSpace m)
   -> m ( InputElement EventResult (DomBuilderSpace m) t
        , Dynamic t (Maybe GasPrice)
        , Event t GasPrice
        )
-uiGasPriceInputField conf = dimensionalInputFeedbackWrapper (Just "KDA") $
- uiNonnegativeRealWithPrecisionInputElement maxCoinPrecision (GasPrice . ParsedDecimal) $ conf
-  & initialAttributes %~ addToClassAttr "input-units"
-  & inputElementConfig_elementConfig . elementConfig_eventSpec %~ preventScrollWheelAndUpDownArrow @m
+uiGasPriceInputField conf = dimensionalInputFeedbackWrapper (Just "KDA") $ do
+  (i, d, e) <- uiNonnegativeRealWithPrecisionInputElement maxCoinPrecision (GasPrice . ParsedDecimal) $ conf
+    & initialAttributes %~ addToClassAttr "input-units"
+    & inputElementConfig_elementConfig . elementConfig_eventSpec %~ preventUpAndDownArrow @m
+  preventScrollWheel $ _inputElement_raw i
+  pure (i, d, e)
 
 
 -- | Let the user pick a chain id.


### PR DESCRIPTION
For some reason, preventDefault stops the event from bubbling in this
case. This workaround is a little heavier than I'd like.