### PR TITLE
WIP: Always parse certificate with LibreSSL

### DIFF
--- a/mac.nix
+++ b/mac.nix
@@ -149,7 +149,7 @@ in rec {
       | sed 's|    "alis"<blob>="\(.*\)"$|\1|' \
       | while read c; do \
           security find-certificate -c "$c" -p \
-            | openssl x509 -subject -noout; \
+            | ${pkgs.libressl}/bin/openssl x509 -subject -noout; \
         done \
       | grep "OU[[:space:]]\?=[[:space:]]\?$TEAM_ID" \
       | sed 's|subject= /UID=[^/]*/CN=\([^/]*\).*|\1|' \


### PR DESCRIPTION
From https://github.com/reflex-frp/reflex-platform/pull/625
Fails to build though, probably fixed in the newer nixpkgs current reflex-platform develop is using