### PR TITLE
Prevent horizontal scrolling in modal main

### DIFF
--- a/backend/sass/common.blocks/_modal.scss
+++ b/backend/sass/common.blocks/_modal.scss
@@ -86,6 +86,7 @@ body[data-modal-open='true'] {
   flex-grow: 1;
   padding: $normal-padding $normal-padding;
   min-height: 6em;
+  overflow-x: hidden;
   overflow-y: auto;
 }
 


### PR DESCRIPTION
This only seems to happen in webkit browsers (and apparently the linux app?). I couldn't find a smaller hammer than this.