### PR TITLE
fix: Constrain feedback on validated input widget

### DIFF
--- a/backend/sass/common.blocks/_input.scss
+++ b/backend/sass/common.blocks/_input.scss
@@ -153,12 +153,4 @@ input[type=number] {
   max-width: 60%;
   height: 1.1em;
   overflow: hidden;
-  z-index: 2;
-  &:hover {
-    height: auto;
-    border: $std-border-width $std-border-style $std-border-color;
-    border-radius: $std-border-radius;
-    padding: 0.2em;
-    box-shadow: 0 0 5px 2px rgba(0, 0, 0, 0.4);
-  }
 }

--- a/backend/sass/common.blocks/_input.scss
+++ b/backend/sass/common.blocks/_input.scss
@@ -145,8 +145,20 @@ input[type=number] {
 
 .dimensional-input__feedback {
   position: absolute;
-  right: 10px;
+  right: 0.5em;
+  padding-left: 0.5em;
+  text-align: right;
   color: $tertiary-color;
   background: white;
-  padding-left: 0.5rem;
+  max-width: 60%;
+  height: 1.1em;
+  overflow: hidden;
+  z-index: 2;
+  &:hover {
+    height: auto;
+    border: $std-border-width $std-border-style $std-border-color;
+    border-radius: $std-border-radius;
+    padding: 0.2em;
+    box-shadow: 0 0 5px 2px rgba(0, 0, 0, 0.4);
+  }
 }

--- a/frontend/src/Frontend/UI/Dialogs/Send.hs
+++ b/frontend/src/Frontend/UI/Dialogs/Send.hs
@@ -286,7 +286,7 @@ sendConfig model fromAccount@(fromName, fromChain, fromAcc) = Workflow $ do
               cannotBeReceiverMsg = "Sender cannot be the receiver of a transfer"
 
           decoded <- fmap snd $ mkLabeledInput True "Kadena Address" (uiInputWithInlineFeedback
-            (fmap (Aeson.eitherDecodeStrict . T.encodeUtf8) . value)
+            (fmap (first (const "Invalid Kadena Address") . Aeson.eitherDecodeStrict . T.encodeUtf8) . value)
             inputIsDirty
             T.pack
             Nothing


### PR DESCRIPTION
Also changes the send dialog to not blurt out an ugly aeson error.

Tried to do a basic hover to unconstrain things in css on hover, but it was pretty ugly and it's probably better just to have concise errors. :)