### PR TITLE
Consistent versioning across all apps

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -8,8 +8,8 @@ with obelisk;
 let
   # All the versions that the user cares about are here so that they can
   # be changed in one place
-  chainWeaverVersion = "1.0";
-  appName = "Kadena Chainweaver ${chainWeaverVersion}";
+  chainweaverVersion = "1.0";
+  appName = "Kadena Chainweaver ${chainweaverVersion}";
   macReleaseNumber = "0";
   linuxReleaseNumber = "0";
   ovaReleaseNumber = "0";
@@ -22,11 +22,11 @@ let
     ${pkgs.sass}/bin/sass ${./backend/sass}/index.scss $out/sass.css
   '';
   macApp = (import ./mac.nix) {
-    inherit obApp pkgs appName sass chainWeaverVersion macReleaseNumber;
+    inherit obApp pkgs appName sass chainweaverVersion macReleaseNumber;
   };
   homeManagerModule = obelisk.reflex-platform.hackGet ./deps/home-manager + /nixos;
   linuxApp = (import ./linux.nix) {
-    inherit obApp pkgs appName sass homeManagerModule chainWeaverVersion linuxReleaseNumber ovaReleaseNumber;
+    inherit obApp pkgs appName sass homeManagerModule chainweaverVersion linuxReleaseNumber ovaReleaseNumber;
   };
 in obApp // rec {
   inherit sass;

--- a/default.nix
+++ b/default.nix
@@ -8,8 +8,8 @@ with obelisk;
 let
   # All the versions that the user cares about are here so that they can
   # be changed in one place
-  chainWeaverVersion = "2.0";
-  appName = "Kadena Chainweaver Beta ${chainWeaverVersion}";
+  chainWeaverVersion = "1.0";
+  appName = "Kadena Chainweaver ${chainWeaverVersion}";
   macReleaseNumber = "0";
   linuxReleaseNumber = "0";
   ovaReleaseNumber = "0";

--- a/default.nix
+++ b/default.nix
@@ -6,6 +6,14 @@ args@{ system ? builtins.currentSystem
 }:
 with obelisk;
 let
+  # All the versions that the user cares about are here so that they can
+  # be changed in one place
+  chainWeaverVersion = "2.0";
+  appName = "Kadena Chainweaver Beta ${chainWeaverVersion}";
+  macReleaseNumber = "0";
+  linuxReleaseNumber = "0";
+  ovaReleaseNumber = "0";
+
   obApp = import ./obApp.nix args;
   pactServerModule = import ./pact-server/service.nix;
   sass = pkgs.runCommand "sass" {} ''
@@ -13,14 +21,12 @@ let
     mkdir $out
     ${pkgs.sass}/bin/sass ${./backend/sass}/index.scss $out/sass.css
   '';
-  appName = "Kadena Chainweaver Beta 2";
-  version = "2020.01.28";
   macApp = (import ./mac.nix) {
-    inherit obApp pkgs appName sass version;
+    inherit obApp pkgs appName sass chainWeaverVersion macReleaseNumber;
   };
   homeManagerModule = obelisk.reflex-platform.hackGet ./deps/home-manager + /nixos;
   linuxApp = (import ./linux.nix) {
-    inherit obApp pkgs appName sass homeManagerModule version;
+    inherit obApp pkgs appName sass homeManagerModule chainWeaverVersion linuxReleaseNumber ovaReleaseNumber;
   };
 in obApp // rec {
   inherit sass;

--- a/linux.nix
+++ b/linux.nix
@@ -1,7 +1,9 @@
 { obApp
 , pkgs
 , appName
-, version
+, chainWeaverVersion
+, linuxReleaseNumber
+, ovaReleaseNumber
 , sass
 , homeManagerModule
 , linuxAppName ? "kadena-chainweaver"
@@ -32,7 +34,7 @@
      exec = "${nixosExe}/bin/${linuxAppName}";
      icon = linuxAppIcon;
   };
-  ova = import ./ova.nix { inherit pkgs nixosExe appName linuxAppName version nixosDesktopItem homeManagerModule linuxAppIcon; };
+  ova = import ./ova.nix { inherit pkgs nixosExe appName linuxAppName chainWeaverVersion ovaReleaseNumber nixosDesktopItem homeManagerModule linuxAppIcon; };
   inherit (ova) chainweaverVM chainweaverVMSystem;
   
   addGObjectIntrospection = hpackage: pkgs.haskell.lib.overrideCabal hpackage (current: {
@@ -231,7 +233,7 @@
   };
   deb-control = pkgs.writeTextFile { name = "control"; text = ''
     Package: ${linuxAppName}
-    Version: ${version}
+    Version: ${chainWeaverVersion}.${linuxReleaseNumber}
     Architecture: amd64
     Maintainer: "Kadena.io"
     Description: ${appName}

--- a/linux.nix
+++ b/linux.nix
@@ -1,7 +1,7 @@
 { obApp
 , pkgs
 , appName
-, chainWeaverVersion
+, chainweaverVersion
 , linuxReleaseNumber
 , ovaReleaseNumber
 , sass
@@ -34,7 +34,7 @@
      exec = "${nixosExe}/bin/${linuxAppName}";
      icon = linuxAppIcon;
   };
-  ova = import ./ova.nix { inherit pkgs nixosExe appName linuxAppName chainWeaverVersion ovaReleaseNumber nixosDesktopItem homeManagerModule linuxAppIcon; };
+  ova = import ./ova.nix { inherit pkgs nixosExe appName linuxAppName chainweaverVersion ovaReleaseNumber nixosDesktopItem homeManagerModule linuxAppIcon; };
   inherit (ova) chainweaverVM chainweaverVMSystem;
   
   addGObjectIntrospection = hpackage: pkgs.haskell.lib.overrideCabal hpackage (current: {
@@ -233,7 +233,7 @@
   };
   deb-control = pkgs.writeTextFile { name = "control"; text = ''
     Package: ${linuxAppName}
-    Version: ${chainWeaverVersion}.${linuxReleaseNumber}
+    Version: ${chainweaverVersion}.${linuxReleaseNumber}
     Architecture: amd64
     Maintainer: "Kadena.io"
     Description: ${appName}

--- a/mac.nix
+++ b/mac.nix
@@ -1,13 +1,15 @@
 { obApp
 , pkgs
 , appName
-, version
+, chainWeaverVersion
+, macReleaseNumber
 , sass
 , macAppIcon ? ./mac/static/icons/kadena.png
 , macPactDocumentIcon ? ./mac/static/icons/pact-document.png
 }:
 let
   macPactDocumentIcon = ./mac/static/icons/pact-document.png;
+  macFullVersion = "${chainWeaverVersion}.${macReleaseNumber}";
   # ^ This can be created in Preview using 'GenericDocumentIcon.icns' from
   # /System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/
   # and the kadena logo
@@ -38,9 +40,9 @@ let
       <key>CFBundleIdentifier</key>
       <string>${bundleIdentifier}</string>
       <key>CFBundleVersion</key>
-      <string>${obApp.ghc.frontend.version}</string>
+      <string>${macFullVersion}</string>
       <key>CFBundleShortVersionString</key>
-      <string>${obApp.ghc.frontend.version}</string>
+      <string>${macFullVersion}</string>
       <key>CFBundlePackageType</key>
       <string>APPL</string>
       <key>CFBundleExecutable</key>
@@ -181,13 +183,13 @@ in rec {
       --icon-size 100 \
       --icon "${appName}.app" 200 190 \
       --app-drop-link 600 185 \
-      "$tmpdir/${appName}.${version}.dmg" \
+      "$tmpdir/${appName}.${macFullVersion}.dmg" \
       "$tmpdir/${appName}.app"
 
     # Sign the dmg
-    /usr/bin/codesign --sign "$signer" "$tmpdir/${appName}.${version}.dmg"
+    /usr/bin/codesign --sign "$signer" "$tmpdir/${appName}.${macFullVersion}.dmg"
 
-    mv "$tmpdir/${appName}.${version}.dmg" .
+    mv "$tmpdir/${appName}.${macFullVersion}.dmg" .
 
     # Quarantine it for reproducibility (otherwise can cause unexpected 'app is damaged' errors when automatically applied to downloaded .dmg files)
     xattr -w com.apple.quarantine "00a3;5d4331e1;Safari;1AE3D17F-B83D-4ADA-94EA-219A44467959" "${appName}.${version}.dmg"

--- a/mac.nix
+++ b/mac.nix
@@ -1,7 +1,7 @@
 { obApp
 , pkgs
 , appName
-, chainWeaverVersion
+, chainweaverVersion
 , macReleaseNumber
 , sass
 , macAppIcon ? ./mac/static/icons/kadena.png
@@ -9,7 +9,7 @@
 }:
 let
   macPactDocumentIcon = ./mac/static/icons/pact-document.png;
-  macFullVersion = "${chainWeaverVersion}.${macReleaseNumber}";
+  macFullVersion = "${chainweaverVersion}.${macReleaseNumber}";
   # ^ This can be created in Preview using 'GenericDocumentIcon.icns' from
   # /System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/
   # and the kadena logo

--- a/mac.nix
+++ b/mac.nix
@@ -192,6 +192,6 @@ in rec {
     mv "$tmpdir/${appName}.${macFullVersion}.dmg" .
 
     # Quarantine it for reproducibility (otherwise can cause unexpected 'app is damaged' errors when automatically applied to downloaded .dmg files)
-    xattr -w com.apple.quarantine "00a3;5d4331e1;Safari;1AE3D17F-B83D-4ADA-94EA-219A44467959" "${appName}.${version}.dmg"
+    xattr -w com.apple.quarantine "00a3;5d4331e1;Safari;1AE3D17F-B83D-4ADA-94EA-219A44467959" "${appName}.${macFullVersion}.dmg"
   '';
 }

--- a/ova.nix
+++ b/ova.nix
@@ -1,4 +1,4 @@
-{ pkgs, nixosExe, appName, linuxAppName, version, nixosDesktopItem, homeManagerModule, linuxAppIcon }:
+{ pkgs, nixosExe, appName, linuxAppName, chainWeaverVersion, ovaReleaseNumber, nixosDesktopItem, homeManagerModule, linuxAppIcon }:
 let
   kadenaOVACache = "https://nixcache.chainweb.com";
   kadenaOVACacheKey = "nixcache.chainweb.com:FVN503ABX9F8x8K0ptnc99XEz5SaA4Sks6kNcZn2pBY=";
@@ -36,7 +36,7 @@ let
 
     (${doUpgradeVM}/bin/${linuxAppName}-do-upgrade $@ && successful) || finished "Update Failed"
   '';
-  versionFile = pkgs.writeText "${linuxAppName}-version" version;
+  versionFile = pkgs.writeText "${linuxAppName}-version" "${chainWeaverVersion}.${ovaReleaseNumber}";
   versionScript = pkgs.writeScriptBin "${linuxAppName}-version.sh" ''cat ${versionFile}'';
   upgradeDesktopItem = pkgs.makeDesktopItem {
      name = "${linuxAppName}-upgrade";
@@ -101,7 +101,7 @@ let
         vmDerivationName = "${linuxAppName}-vm";
         # This should not be Appname as this name will persist forever in the users virtualbox.
         vmName = "Kadena Chainweaver VM";
-        vmFileName = "${linuxAppName}-vm.${version}.ova";
+        vmFileName = "${linuxAppName}-vm.${chainWeaverVersion}.${ovaReleaseNumber}.ova";
       };
     };
   });

--- a/ova.nix
+++ b/ova.nix
@@ -1,4 +1,4 @@
-{ pkgs, nixosExe, appName, linuxAppName, chainWeaverVersion, ovaReleaseNumber, nixosDesktopItem, homeManagerModule, linuxAppIcon }:
+{ pkgs, nixosExe, appName, linuxAppName, chainweaverVersion, ovaReleaseNumber, nixosDesktopItem, homeManagerModule, linuxAppIcon }:
 let
   kadenaOVACache = "https://nixcache.chainweb.com";
   kadenaOVACacheKey = "nixcache.chainweb.com:FVN503ABX9F8x8K0ptnc99XEz5SaA4Sks6kNcZn2pBY=";
@@ -36,7 +36,7 @@ let
 
     (${doUpgradeVM}/bin/${linuxAppName}-do-upgrade $@ && successful) || finished "Update Failed"
   '';
-  versionFile = pkgs.writeText "${linuxAppName}-version" "${chainWeaverVersion}.${ovaReleaseNumber}";
+  versionFile = pkgs.writeText "${linuxAppName}-version" "${chainweaverVersion}.${ovaReleaseNumber}";
   versionScript = pkgs.writeScriptBin "${linuxAppName}-version.sh" ''cat ${versionFile}'';
   upgradeDesktopItem = pkgs.makeDesktopItem {
      name = "${linuxAppName}-upgrade";
@@ -101,7 +101,7 @@ let
         vmDerivationName = "${linuxAppName}-vm";
         # This should not be Appname as this name will persist forever in the users virtualbox.
         vmName = "Kadena Chainweaver VM";
-        vmFileName = "${linuxAppName}-vm.${chainWeaverVersion}.${ovaReleaseNumber}.ova";
+        vmFileName = "${linuxAppName}-vm.${chainweaverVersion}.${ovaReleaseNumber}.ova";
       };
     };
   });


### PR DESCRIPTION
Mac means that we need a X.Y.Z version. 

This makes the "chainweaver" version the X.Y part that is shared across all apps, but lets us make platform specific changes in the Z number. 

X is reserved for big UI changes, where Y is for smaller features and non platform specific fixes.

All in the toplevel default.nix so that all versions are changed in those handful of lines so things aren't forgotten.

We're dropping the "Beta" prefix and going to 1.0 as the first real proper version. A little odd because the last mac version was 1.5.1.2 but no one will mind. Anagha and Doug are on board with this being the next version number. 