### PR TITLE
Bunch of fixes

### DIFF
--- a/backend/sass/common.blocks/_wallet.scss
+++ b/backend/sass/common.blocks/_wallet.scss
@@ -34,6 +34,10 @@
   overflow: hidden;
 }
 
+.wallet__table-cell-balance {
+  word-break: break-word;
+}
+
 .wallet__table-cell-keyset {
   white-space: nowrap;
   text-overflow: ellipsis;

--- a/frontend/src/Frontend/UI/Dialogs/AddVanityAccount.hs
+++ b/frontend/src/Frontend/UI/Dialogs/AddVanityAccount.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecursiveDo #-}
+{-# LANGUAGE TupleSections #-}
 module Frontend.UI.Dialogs.AddVanityAccount
   ( uiAddAccountButton
   , uiCreateAccountButton
@@ -86,7 +86,7 @@ uiAddAccountDialog model _onCloseExternal = mdo
     divClass "group" $ do
       uiAccountNameInput model Nothing
   add <- modalFooter $ do
-    confirmButton def "Add Account"
+    confirmButton (def & uiButtonCfg_disabled .~ (isNothing <$> name)) "Add Account"
   let val = runMaybeT $ do
         net <- lift $ current $ model ^. network_selectedNetwork
         n <- MaybeT $ current name

--- a/frontend/src/Frontend/UI/Dialogs/AddVanityAccount.hs
+++ b/frontend/src/Frontend/UI/Dialogs/AddVanityAccount.hs
@@ -92,7 +92,8 @@ uiAddAccountDialog model _onCloseExternal = mdo
         n <- MaybeT $ current name
         pure (net, n)
       conf = mempty & walletCfg_importAccount .~ tagMaybe val add
-  return (conf, onClose)
+  -- Since this always succeeds, we're okay to close on the add button event
+  return (conf, onClose <> add)
 
 uiCreateAccountButton :: DomBuilder t m => UiButtonCfg -> m (Event t ())
 uiCreateAccountButton cfg =

--- a/frontend/src/Frontend/UI/Wallet.hs
+++ b/frontend/src/Frontend/UI/Wallet.hs
@@ -199,7 +199,8 @@ uiAccountItem keys name accountInfo = do
     [ "class" =: "wallet__table-row"
     , if v then mempty else "style" =: "display:none"
     ]
-  td = elClass "td" "wallet__table-cell"
+  td = td' ""
+  td' extraClass = elClass "td" ("wallet__table-cell" <> extraClass)
   buttons = divClass "wallet__table-buttons"
   cfg = def
     & uiButtonCfg_class <>~ "wallet__table-button"
@@ -210,7 +211,7 @@ uiAccountItem keys name accountInfo = do
     td $ text $ unAccountName name
     td blank -- Keyset info column
     td $ dynText $ maybe "" unAccountNotes <$> notes
-    td $ dynText $ uiAccountBalance False . Just <$> balance
+    td' " wallet__table-cell-balance" $ dynText $ uiAccountBalance False . Just <$> balance
     onDetails <- td $ buttons $ detailsIconButton cfg
     pure (clk, AccountDialog_Details name <$> current notes <@ onDetails)
 
@@ -223,7 +224,7 @@ uiAccountItem keys name accountInfo = do
       AccountStatus_DoesNotExist -> "Does not exist"
       AccountStatus_Exists d -> keysetSummary $ _accountDetails_keyset d
     td $ dynText $ maybe "" unAccountNotes . _vanityAccount_notes . _account_storage <$> dAccount
-    td $ dynText $ fmap (uiAccountBalance' False) dAccount
+    td' " wallet__table-cell-balance" $ dynText $ fmap (uiAccountBalance' False) dAccount
     td $ buttons $ do
       action <- switchHold never <=< dyn $ ffor accStatus $ \case
         AccountStatus_Unknown -> pure never

--- a/frontend/src/Frontend/Wallet.hs
+++ b/frontend/src/Frontend/Wallet.hs
@@ -52,6 +52,7 @@ import Control.Monad (guard, void)
 import Control.Monad.Except (runExcept)
 import Control.Monad.Fix
 import Data.Aeson
+import Data.Bifunctor (first)
 import Data.Either (rights)
 import Data.IntMap (IntMap)
 import Data.Map (Map)
@@ -329,7 +330,8 @@ checkAccountNameValidity
 checkAccountNameValidity m = getErr <$> (m ^. network_selectedNetwork) <*> (m ^. wallet_accounts)
   where
     getErr net (AccountData networks) k = do
-      acc <- mkAccountName k
+      -- TODO: Remove this hushing of the Kadena error once our error display is better.
+      acc <- first (const "Invalid Account Name") $ mkAccountName k
       maybe (Right acc) (\_ -> Left "This account name is already in use") $ do
         accounts <- Map.lookup net networks
         guard $ Map.member acc accounts


### PR DESCRIPTION
We had a bug report that the balance was truncated. Wordbreak so this doesn't happen. 

Tweaks add account dialog to disable the add button till there is a valid name, truncate the error for smaller screens and to close the dialog when the button is clicked / account is added.  