### PR TITLE
Limit selection of accounts using keyset predicates

### DIFF
--- a/common/src/Common/Wallet.hs
+++ b/common/src/Common/Wallet.hs
@@ -399,20 +399,17 @@ filterKeyPairs s m = Map.elems $ Map.restrictKeys (toMap m) s
   where toMap = Map.fromList . fmap (\k -> (_keyPair_publicKey $ _key_pair k, _key_pair k)) . IntMap.elems
 
 keysetSatisfiesPredicate :: AddressKeyset -> IntMap (Key key) -> Bool
-keysetSatisfiesPredicate ak keys0
-  | addpred <- _addressKeyset_pred ak, addpred `elem` predefinedPreds =
-      let
-        keys = Set.fromList $ fmap (_keyPair_publicKey . _key_pair) $ IntMap.elems keys0
-        kskeys = _addressKeyset_keys ak
-        keyIntersections = Set.intersection kskeys keys
-      in
-        case _addressKeyset_pred ak of
-          "keys-all" -> kskeys == keyIntersections
-          "keys-any" -> not $ Set.null keyIntersections
-          "keys-2" -> length keyIntersections >= 2
-          _ -> False
-  | otherwise =
-      not $ null $ filterKeyPairs (_addressKeyset_keys ak) keys0
+keysetSatisfiesPredicate ak keys0 =
+  let
+    keys = Set.fromList $ fmap (_keyPair_publicKey . _key_pair) $ IntMap.elems keys0
+    kskeys = _addressKeyset_keys ak
+    keyIntersections = Set.intersection kskeys keys
+  in
+    case _addressKeyset_pred ak of
+      "keys-all" -> kskeys == keyIntersections
+      "keys-any" -> not $ Set.null keyIntersections
+      "keys-2" -> length keyIntersections >= 2
+      _ -> not $ null $ filterKeyPairs (_addressKeyset_keys ak) keys0
 
 newtype Accounts = Accounts
   { _accounts_vanity :: Map AccountName (AccountInfo VanityAccount)

--- a/common/src/Common/Wallet.hs
+++ b/common/src/Common/Wallet.hs
@@ -30,6 +30,8 @@ module Common.Wallet
   , addressKeysetObject
   , addressKeyset_keys
   , addressKeyset_pred
+  , predefinedPreds
+  , keysetSatisfiesPredicate
   , toPactKeyset
   , fromPactKeyset
   , AccountNotes (unAccountNotes)
@@ -384,12 +386,33 @@ instance FromJSON key => FromJSON (Key key) where
       { _key_pair = pair
       }
 
-
 type KeyStorage key = IntMap (Key key)
+
+-- | Predefined predicates in Pact.
+--
+--   Userdefined ones are possible too, although the UI currently does not support them.
+predefinedPreds :: [ Text ]
+predefinedPreds = [ "keys-all", "keys-2", "keys-any" ]
 
 filterKeyPairs :: Set PublicKey -> IntMap (Key key) -> [KeyPair key]
 filterKeyPairs s m = Map.elems $ Map.restrictKeys (toMap m) s
   where toMap = Map.fromList . fmap (\k -> (_keyPair_publicKey $ _key_pair k, _key_pair k)) . IntMap.elems
+
+keysetSatisfiesPredicate :: AddressKeyset -> IntMap (Key key) -> Bool
+keysetSatisfiesPredicate ak keys0
+  | addpred <- _addressKeyset_pred ak, addpred `elem` predefinedPreds =
+      let
+        keys = Set.fromList $ fmap (_keyPair_publicKey . _key_pair) $ IntMap.elems keys0
+        kskeys = _addressKeyset_keys ak
+        keyIntersections = Set.intersection kskeys keys
+      in
+        case _addressKeyset_pred ak of
+          "keys-all" -> kskeys == keyIntersections
+          "keys-any" -> not $ Set.null keyIntersections
+          "keys-2" -> length keyIntersections >= 2
+          _ -> False
+  | otherwise =
+      not $ null $ filterKeyPairs (_addressKeyset_keys ak) keys0
 
 newtype Accounts = Accounts
   { _accounts_vanity :: Map AccountName (AccountInfo VanityAccount)

--- a/frontend/src/Frontend/JsonData.hs
+++ b/frontend/src/Frontend/JsonData.hs
@@ -179,12 +179,6 @@ getJsonDataObjectLax jd = ffor (_jsonData_data jd) $ \(keysetsObj, rawParse) -> 
 getJsonDataObjectStrict :: Reflex t => JsonData t -> Dynamic t (Either JsonError Object)
 getJsonDataObjectStrict jd = ffor (_jsonData_data jd) $ \(keysetsObj, rawParse) -> (keysetsObj <>) <$> rawParse
 
--- | Predefined predicates in Pact.
---
---   Userdefined ones are possible too, although the UI currently does not support them.
-predefinedPreds :: [ Text ]
-predefinedPreds = ["keys-all", "keys-2", "keys-any"]
-
 -- | Build `JsonData` by means of the given `Wallet` and `JsonDataCfg`.
 makeJsonData
   :: forall key t m. (MonadHold t m, PerformEvent t m, MonadFix m)

--- a/frontend/src/Frontend/UI/Widgets.hs
+++ b/frontend/src/Frontend/UI/Widgets.hs
@@ -950,11 +950,15 @@ mkChainTextAccounts m needsGas mChainId = runExceptT $ do
   -- Calculating the max gas from the network meta causes a causality loop
   -- maxGasPriceBalance <- lift $ AccountBalance . calcMaxGas <$> m ^. network_meta
 
+  keys <- lift $ m ^. wallet_keys
   chain <- ExceptT $ note "You must select a chain ID before choosing an account" <$> mChainId
   accountsOnNetwork <- ExceptT $ note "No accounts on current network" . Map.lookup netId . unAccountData <$> m ^. wallet_accounts
   let mkVanity n (AccountInfo _ chainMap)
-        | Just a <- Map.lookup chain chainMap
+        | Just a <- Map.lookup chain chainMap, allowAcc n a = Map.singleton n (unAccountName n)
         , not needsGas || (fromMaybe 0 (a ^? account_status . _AccountStatus_Exists . accountDetails_balance)) > 0
+        -- Only select _our_ accounts. TODO: run pact code to ensure keyset predicate(s)
+        -- are satisfied so we're able to handle user created predicates correctly.
+        , not . null $ filterKeyPairs (accountKeys a) keys
         = Map.singleton n (unAccountName n)
         | otherwise = mempty
       vanityAccounts = Map.foldMapWithKey mkVanity accountsOnNetwork

--- a/frontend/src/Frontend/UI/Widgets.hs
+++ b/frontend/src/Frontend/UI/Widgets.hs
@@ -947,37 +947,21 @@ mkChainTextAccounts
   -> Dynamic t (Either Text (Map AccountName Text))
 mkChainTextAccounts m needsGas mChainId = runExceptT $ do
   netId <- lift $ m ^. network_selectedNetwork
-  -- Calculating the max gas from the network meta causes a causality loop
-  -- maxGasPriceBalance <- lift $ AccountBalance . calcMaxGas <$> m ^. network_meta
 
   keys <- lift $ m ^. wallet_keys
   chain <- ExceptT $ note "You must select a chain ID before choosing an account" <$> mChainId
   accountsOnNetwork <- ExceptT $ note "No accounts on current network" . Map.lookup netId . unAccountData <$> m ^. wallet_accounts
   let mkVanity n (AccountInfo _ chainMap)
-        | Just a <- Map.lookup chain chainMap, allowAcc n a = Map.singleton n (unAccountName n)
-        , not needsGas || (fromMaybe 0 (a ^? account_status . _AccountStatus_Exists . accountDetails_balance)) > 0
+        | Just a <- Map.lookup chain chainMap
         -- Only select _our_ accounts. TODO: run pact code to ensure keyset predicate(s)
         -- are satisfied so we're able to handle user created predicates correctly.
-        , not . null $ filterKeyPairs (accountKeys a) keys
-        = Map.singleton n (unAccountName n)
+        , accountSatisfiesKeysetPredicate keys a
+        , allowAcc n a = Map.singleton n (unAccountName n)
         | otherwise = mempty
       vanityAccounts = Map.foldMapWithKey mkVanity accountsOnNetwork
       accountsOnChain = vanityAccounts
   when (Map.null accountsOnChain) $ throwError "No accounts on current chain"
   pure accountsOnChain
-  -- where
-  --  calcMaxGas :: PublicMeta -> Decimal
-  --  calcMaxGas meta =
-  --    (meta ^. pmGasLimit . to gasLimitToDecimal)
-  --    *
-  --    (meta ^. pmGasPrice . to gasPriceToDecimal)
-  --  -- from some reason, _Wrapped wasn't working for me. Probably pebkac
-  --  gasLimitToDecimal :: GasLimit -> Decimal
-  --  gasLimitToDecimal (GasLimit (ParsedInteger l)) = fromIntegral l
-  --  gasPriceToDecimal :: GasPrice -> Decimal
-  --  gasPriceToDecimal (GasPrice (ParsedDecimal p)) = p
-
-
 
 -- | Let the user pick an account
 uiAccountDropdown'

--- a/frontend/src/Frontend/Wallet.hs
+++ b/frontend/src/Frontend/Wallet.hs
@@ -33,6 +33,8 @@ module Frontend.Wallet
   , AccountData (..)
   , _AccountData
   , accountKeys
+  , accountHasFunds
+  , accountSatisfiesKeysetPredicate
   -- * Creation
   , makeWallet
   , loadKeys
@@ -151,6 +153,14 @@ getSigningPairs chain allKeys allAccounts signing = filterKeyPairs (Set.unions w
 -- TODO replace this at the use sites with proper multisig
 accountKeys :: Account -> Set.Set PublicKey
 accountKeys a = a ^. account_status . _AccountStatus_Exists . accountDetails_keyset . addressKeyset_keys
+
+accountHasFunds :: Account -> Maybe Bool
+accountHasFunds a = fmap (> 0) $ a ^? account_status . _AccountStatus_Exists . accountDetails_balance
+
+accountSatisfiesKeysetPredicate :: IntMap (Key key) -> Account -> Bool
+accountSatisfiesKeysetPredicate keys a = fromMaybe False
+  $ fmap (flip keysetSatisfiesPredicate keys)
+  $ a ^? account_status . _AccountStatus_Exists . accountDetails_keyset
 
 snocIntMap :: a -> IntMap a -> IntMap a
 snocIntMap a m = IntMap.insert (nextKey m) a m


### PR DESCRIPTION
Only the predefined predicates are handled at this stage, custom predicates are treated the say as `keys-all` for now.