### PR TITLE
Wrap external key inputs and add bottom margin to match zeplin.

### DIFF
--- a/backend/sass/common.blocks/_input.scss
+++ b/backend/sass/common.blocks/_input.scss
@@ -153,5 +153,8 @@ input[type=number] {
   background: white;
   max-width: 60%;
   height: 1.1em;
-  overflow: hidden;
+}
+
+.define-keyset__external-key-input {
+  margin-bottom: 10px;
 }

--- a/frontend/src/Frontend/UI/Dialogs/AddVanityAccount/DefineKeyset.hs
+++ b/frontend/src/Frontend/UI/Dialogs/AddVanityAccount/DefineKeyset.hs
@@ -57,7 +57,7 @@ uiExternalKeyInput
 uiExternalKeyInput onPreselection = do
   let
     uiPubkeyInput :: Maybe Text -> m (ExternalKeyInput t)
-    uiPubkeyInput iv = do
+    uiPubkeyInput iv = divClass "define-keyset__external-key-input" $ do
       (inp, dE) <- uiInputWithInlineFeedback
         (fmap parsePublicKey . value)
         (fmap (not . T.null) . value)


### PR DESCRIPTION
Remove overflow:hidden from dimentional input message as it was hiding the lower portion
of the words in the message.