### PR TITLE
Allow signing of requests from other networks.

### DIFF
--- a/frontend/src/Frontend/Network/NodeInfo.hs
+++ b/frontend/src/Frontend/Network/NodeInfo.hs
@@ -112,8 +112,8 @@ data NodeInfo = NodeInfo
 
 nodeVersion :: NodeInfo -> Text
 nodeVersion ni = case _nodeInfo_type ni of
-                   NodeType_Pact _v -> ""
-                   NodeType_Chainweb ci -> _chainwebInfo_networkVersion ci
+  NodeType_Pact v -> v
+  NodeType_Chainweb ci -> _chainwebInfo_networkVersion ci
 
 -- | Retrive the `NodeInfo` for a given host by quering its API.
 discoverNode :: forall m. (MonadJSM m, MonadUnliftIO m, HasJSContext m) => NodeRef -> m (Either Text NodeInfo)

--- a/frontend/src/Frontend/UI/DeploymentSettings.hs
+++ b/frontend/src/Frontend/UI/DeploymentSettings.hs
@@ -79,9 +79,9 @@ import Pact.Compile (compileExps, mkTextInfo)
 import Pact.Parse
 import Pact.Types.Capability
 import Pact.Types.ChainMeta (PublicMeta (..), TTLSeconds (..))
-import Pact.Types.PactValue (PactValue (PLiteral), toPactValue)
+import Pact.Types.PactValue (toPactValue)
 import Pact.Types.Pretty
-import Pact.Types.Runtime (App(..), GasLimit (..), Literal (LString), GasPrice (..), Name(..), Term(..), hashToText, toUntypedHash)
+import Pact.Types.Runtime (App(..), GasLimit (..), GasPrice (..), Name(..), Term(..), hashToText, toUntypedHash)
 import Reflex
 import Reflex.Dom
 import Reflex.Dom.Contrib.CssClass (elKlass)
@@ -1052,10 +1052,11 @@ uiDeployPreview model settings signers gasLimit ttl code lastPublicMeta capabili
             if isChainwebNode then
               parseWrappedBalanceChecks
             else
-              -- Non-chainweb nodes won't have the expected contracts to utilise wrapped balance checks
-              \case
-                pv@(PLiteral (LString _)) -> Right (fmap (const Nothing) accountsToTrack, pv)
-                v -> Left $ "Unexpected PactValue: " <> renderCompactText v
+              -- Non-chainweb nodes won't have the expected contracts to utilise wrapped
+              -- balance checks, so we don't know what structure to expect here.
+              -- Kuro returns a (PLiteral (LString ...))
+              -- Chainweb returns a (PObject ...)
+              \pv -> Right (fmap (const Nothing) accountsToTrack, pv)
 
       responses <- performLocalRead (model ^. logger) (model ^. network) $ localReq <$ pb
       (errors, resp) <- fmap fanThese $ performEvent $ ffor responses $ \case

--- a/frontend/src/Frontend/UI/DeploymentSettings.hs
+++ b/frontend/src/Frontend/UI/DeploymentSettings.hs
@@ -79,9 +79,9 @@ import Pact.Compile (compileExps, mkTextInfo)
 import Pact.Parse
 import Pact.Types.Capability
 import Pact.Types.ChainMeta (PublicMeta (..), TTLSeconds (..))
-import Pact.Types.PactValue (toPactValue)
+import Pact.Types.PactValue (PactValue (PLiteral), toPactValue)
 import Pact.Types.Pretty
-import Pact.Types.Runtime (App(..), GasLimit (..), GasPrice (..), Name(..), Term(..), hashToText, toUntypedHash)
+import Pact.Types.Runtime (App(..), GasLimit (..), Literal (LString), GasPrice (..), Name(..), Term(..), hashToText, toUntypedHash)
 import Reflex
 import Reflex.Dom
 import Reflex.Dom.Contrib.CssClass (elKlass)
@@ -982,6 +982,12 @@ uiDeployPreview model settings signers gasLimit ttl code lastPublicMeta capabili
       signingPairs = Map.keys capabilities <> Set.toList signers
       publicKeyCapabilities = disregardPrivateKey capabilities
 
+      isChainwebNode (NodeType_Pact _) = False
+      isChainwebNode (NodeType_Chainweb _) = True
+
+      dIsChainWebNode = maybe False (isChainwebNode . _nodeInfo_type) . headMay . rights
+        <$> model ^. network_selectedNodes
+
   let publicMeta = lastPublicMeta
         { _pmChainId = chainId
         , _pmGasLimit = gasLimit
@@ -993,17 +999,29 @@ uiDeployPreview model settings signers gasLimit ttl code lastPublicMeta capabili
       extraSigners = _deploymentSettingsConfig_extraSigners settings
       jsondata = HM.union jsonData0 deploySettingsJsonData
 
-  eCmds <- performEvent $ ffor pb $ \_ -> do
-    c <- buildCmd nonce networkId publicMeta signingPairs extraSigners code jsondata publicKeyCapabilities
-    wc <- for (wrapWithBalanceChecks (Set.singleton sender) code) $ \wrappedCode -> do
-      buildCmd nonce networkId publicMeta signingPairs extraSigners wrappedCode jsondata publicKeyCapabilities
+  let
+    mkBuildCmd code0 = buildCmd nonce networkId publicMeta signingPairs
+      extraSigners code0 jsondata publicKeyCapabilities
+
+  eCmds <- performEvent $ ffor (current dIsChainWebNode <@ pb) $ \onChainweb -> do
+    c <- mkBuildCmd code
+    wc <-
+      if onChainweb then
+        Just <$> for (wrapWithBalanceChecks (Set.singleton sender) code) mkBuildCmd
+      else
+        pure Nothing
     pure (c, wc)
 
   void $ runWithReplace
     (text "Preparing transaction preview...")
-    (uiPreviewResponses <$> current (model ^. network_selectedNetwork) <*> current (model ^. wallet_accounts) <@> eCmds)
+    ( uiPreviewResponses
+      <$> current (model ^. network_selectedNetwork)
+      <*> current (model ^. wallet_accounts)
+      <*> current dIsChainWebNode
+      <@> eCmds
+    )
   where
-    uiPreviewResponses networkName accountData (cmd, wrappedCmd) = do
+    uiPreviewResponses networkName accountData isChainwebNode (cmd, mWrappedCmd) = do
       pb <- getPostBuild
 
       unless (any (any isGas) capabilities) $ do
@@ -1022,16 +1040,29 @@ uiDeployPreview model settings signers gasLimit ttl code lastPublicMeta capabili
         uiAccountFixed sender
 
       let accountsToTrack = getAccounts networkName accountData
-          localReq = case wrappedCmd of
-            Left _e -> []
-            Right cmd0 -> pure $ NetworkRequest
+          localReq = case mWrappedCmd of
+            Nothing -> []
+            Just (Left _e) -> []
+            Just (Right cmd0) -> pure $ NetworkRequest
               { _networkRequest_cmd = cmd0
               , _networkRequest_chainRef = ChainRef Nothing chainId
               , _networkRequest_endpoint = Endpoint_Local
               }
+          parseChainwebWrapped =
+            if isChainwebNode then
+              parseWrappedBalanceChecks
+            else
+              -- Non-chainweb nodes won't have the expected contracts to utilise wrapped balance checks
+              \case
+                pv@(PLiteral (LString _)) -> Right (fmap (const Nothing) accountsToTrack, pv)
+                v -> Left $ "Unexpected PactValue: " <> renderCompactText v
+
       responses <- performLocalRead (model ^. logger) (model ^. network) $ localReq <$ pb
       (errors, resp) <- fmap fanThese $ performEvent $ ffor responses $ \case
-        [(_, errorResult)] -> parseNetworkErrorResult (model ^. logger) parseWrappedBalanceChecks errorResult
+        [(_, errorResult)] -> parseNetworkErrorResult
+          (model ^. logger)
+          parseChainwebWrapped
+          errorResult
         n -> do
           putLog model LevelWarn $ "Expected 1 response, but got " <> tshow (length n)
           pure $ This "Couldn't get a response from the node"
@@ -1046,7 +1077,10 @@ uiDeployPreview model settings signers gasLimit ttl code lastPublicMeta capabili
             th "Public Key"
             th "Change in Balance"
           accountBalances <- flip Map.traverseWithKey accountsToTrack $ \acc pks -> do
-            bal <- holdDyn Nothing $ leftmost [Just Nothing <$ errors, Just . join . Map.lookup acc . fst <$> resp]
+            bal <- holdDyn Nothing $ leftmost
+              [ Just Nothing <$ errors
+              , Just . join . Map.lookup acc . fst <$> resp
+              ]
             pure (pks, bal)
           el "tbody" $ void $ flip Map.traverseWithKey accountBalances $ \acc (pks, balance) -> el "tr" $ do
             let displayBalance = \case
@@ -1058,7 +1092,8 @@ uiDeployPreview model settings signers gasLimit ttl code lastPublicMeta capabili
             el "td" $ dynText $ displayBalance <$> balance
 
       dialogSectionHeading mempty "Raw Response"
-      void $ divClass "group segment transaction_details__raw-response" $ runWithReplace (text "Loading...") $ leftmost
+      void $ divClass "group segment transaction_details__raw-response"
+        $ runWithReplace (text "Loading...") $ leftmost
         [ text . renderCompactText . snd <$> resp
         , text <$> errors
         ]


### PR DESCRIPTION
If we're not on the chainweb node then don't attempt to run coin contract code, provide
nicer feedback to the user using what information we can reliably glean from network
responses.

There is no expectation of being able to retrieve balances etc whilst on a non-coin
contract network.