### PR TITLE
Refactor 'Watch Request' to 'Check TX Status'

### DIFF
--- a/backend/sass/common.blocks/_modal.scss
+++ b/backend/sass/common.blocks/_modal.scss
@@ -378,3 +378,7 @@ button.button.button_type_tertiary.logout-confirm-modal__button {
     color: $black-text;
   }
 }
+
+.check-tx-status__button-wrapper {
+  text-align: right;
+}

--- a/frontend/src/Frontend/UI/Dialogs/DeployConfirmation.hs
+++ b/frontend/src/Frontend/UI/Dialogs/DeployConfirmation.hs
@@ -208,10 +208,18 @@ newTriggerHold a = do
   pure (s, liftIO . t)
 
 listenToRequestKey
-  :: (MonadHold t m, PerformEvent t m, TriggerEvent t m, MonadIO m, MonadJSM (Performable m))
+  :: ( MonadHold t m
+     , PerformEvent t m
+     , TriggerEvent t m
+     , MonadIO m
+     , MonadJSM (Performable m)
+     )
   => [S.ClientEnv]
   -> Event t (Maybe Pact.RequestKey)
-  -> m (Dynamic t Status, Dynamic t (Maybe (Either NetworkError PactValue)), Maybe (Either NetworkError PactValue) -> JSM ())
+  -> m ( Dynamic t Status
+       , Dynamic t (Maybe (Either NetworkError PactValue))
+       , Maybe (Either NetworkError PactValue) -> JSM ()
+       )
 listenToRequestKey clientEnvs onRequestKey = do
   (listenStatus, listen) <- newTriggerHold Status_Waiting
   --(confirmedStatus, confirm) <- newTriggerHold Status_Waiting

--- a/frontend/src/Frontend/UI/Dialogs/Receive.hs
+++ b/frontend/src/Frontend/UI/Dialogs/Receive.hs
@@ -14,6 +14,8 @@ import Control.Lens ((^.), (<>~), (^?), to)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Maybe (MaybeT(..))
 
+import Data.Text (Text)
+
 import Reflex
 import Reflex.Dom
 

--- a/frontend/src/Frontend/UI/Dialogs/WatchRequest.hs
+++ b/frontend/src/Frontend/UI/Dialogs/WatchRequest.hs
@@ -97,9 +97,9 @@ inputRequestKey model _ = Workflow $ do
 
       onTimeoutFinished <- delay 5 onRequest
 
-      blockSpam <- toggle False $ leftmost
-        [ onRequest
-        , onTimeoutFinished
+      blockSpam <- holdDyn False $ leftmost
+        [ True <$ onRequest
+        , False <$ onTimeoutFinished
         ]
 
     onPollResponse <- performEventAsync $ pollRequestKey


### PR DESCRIPTION
Now uses `/poll` instead of `/listen` and does not require a ChainID.