### PR TITLE
Add safe transfers

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -8,7 +8,7 @@ with obelisk;
 let
   # All the versions that the user cares about are here so that they can
   # be changed in one place
-  chainweaverVersion = "2.0";
+  chainweaverVersion = "2.1";
   appName = "Kadena Chainweaver";
   macReleaseNumber = "0";
   linuxReleaseNumber = "0";

--- a/frontend/src/Frontend/UI/Transfer.hs
+++ b/frontend/src/Frontend/UI/Transfer.hs
@@ -351,6 +351,9 @@ getAccountDetails model eca = do
                    nodes chain [acct]
       pure $ extractDetails <$> ks
 
+transferModalTitle :: TransferType -> Text
+transferModalTitle NormalTransfer = "Transfer"
+transferModalTitle SafeTransfer = "Safe Transfer"
 
 lookupAndTransfer
   :: ( MonadWidget t m, Monoid mConf, Flattenable mConf t
@@ -394,9 +397,9 @@ lookupAndTransfer model netInfo ti ty onCloseExternal = do
           mConf <- flatten =<< tagOnPostBuild conf
           let close = switch $ current closes
           pure (mConf, close)
-        eWrapper (_, Nothing) = msgModal "Sign Transfer" $ text "Loading..."
-        eWrapper (Nothing, _) = msgModal "Sign Transfer" $ text "Loading..."
-    (conf, closes) <- splitDynPure <$> networkHold (msgModal "Sign Transfer" $ text "Querying keysets...")
+        eWrapper (_, Nothing) = msgModal (transferModalTitle ty) $ text "Loading..."
+        eWrapper (Nothing, _) = msgModal (transferModalTitle ty) $ text "Loading..."
+    (conf, closes) <- splitDynPure <$> networkHold (msgModal (transferModalTitle ty) $ text "Querying keysets...")
                         (eWrapper <$> ffilter (\(a,b) -> isJust a && isJust b) (updated allKeys))
     mConf <- flatten =<< tagOnPostBuild conf
     return (mConf, switch $ current closes)
@@ -608,7 +611,7 @@ transferDialog
 transferDialog model netInfo ti ty fks tks _ = do
     -- TODO Clean up the unused parameter
     -- It contains the from account name and details retrieved from blockchain
-    close <- modalHeader $ text "Sign Transfer"
+    close <- modalHeader $ text $ transferModalTitle ty
     rec
       (currentTab, _done) <- transferTabs newTab
       (conf, meta, payload, dSignedCmd, destChainInfo) <- mainSection currentTab

--- a/frontend/src/Frontend/UI/Transfer.hs
+++ b/frontend/src/Frontend/UI/Transfer.hs
@@ -264,6 +264,14 @@ uiGenericTransfer model cfg = do
           safeDisabled (Just i) = _ca_chain (_ti_fromAccount i) /= _ca_chain (_ti_toAccount i)
                                || (Set.null . _userKeyset_keys <$> _ti_toKeyset i) == Just True
                                || isNothing (_ti_toKeyset i)
+                               || _ti_maxAmount i
+          -- It doesn't make sense to do safe transfer with max amount because
+          -- the receiver sends coins back to the sender. If someone wants to do
+          -- this, they can first do a safe transfer to create the new account
+          -- and then do a second transfer for the max balance. The convenience
+          -- of doing it in one transaction is not worth the additional code
+          -- complexity.
+
           safeBtnCfg = def
             { _uiButtonCfg_disabled = (safeDisabled <$> transferInfo)
             , _uiButtonCfg_title = constDyn $ Just "Safe transfers can be done when you are doing a transfer-create to the same chain.  This makes it impossible for you to lose coins by sending it to the wrong public key.  It requires a little extra work because the receiving account also has to sign the transaction."

--- a/frontend/src/Frontend/UI/Transfer.hs
+++ b/frontend/src/Frontend/UI/Transfer.hs
@@ -908,8 +908,11 @@ buildUnsignedCmd netInfo ti ty tmeta = payload
                     Just ks ->
                       -- This has to match epsilon in transferMetadata
                       let epsilon = "0.000000000001"
-                          there = printf "(coin.transfer-create %s %s (read-keyset %s) (+ %s %s))"
-                                    (show fromAccount) (show toAccount) (show dataKey) amountString epsilon
+                          amountExpr = case ty of
+                            NormalTransfer -> amountString
+                            SafeTransfer -> printf "(+ %s %s)" amountString epsilon
+                          there = printf "(coin.transfer-create %s %s (read-keyset %s) %s)"
+                                    (show fromAccount) (show toAccount) (show dataKey) amountExpr
                           back = printf "(coin.transfer %s %s %s)"
                                     (show toAccount) (show fromAccount) epsilon
                       in (Just dataKey, if ty == SafeTransfer then unlines [there, back] else there)


### PR DESCRIPTION
Safe transfers make it impossible for you to lose coins when transferring to a new account.  We accomplish this by transferring a small amount back to the sender in the same transaction.  This requires the transaction to be signed by the receiving account, guaranteeing that the receiving account's keyset is valid.