### PR TITLE
Bump servant-jsaddle to fix encoding bug

### DIFF
--- a/dep/servant-jsaddle/default.nix
+++ b/dep/servant-jsaddle/default.nix
@@ -1,0 +1,7 @@
+# DO NOT HAND-EDIT THIS FILE
+import ((import <nixpkgs> {}).fetchFromGitHub (
+  let json = builtins.fromJSON (builtins.readFile ./github.json);
+  in { inherit (json) owner repo rev sha256;
+       private = json.private or false;
+     }
+))

--- a/dep/servant-jsaddle/github.json
+++ b/dep/servant-jsaddle/github.json
@@ -1,0 +1,7 @@
+{
+  "owner": "kadena-io",
+  "repo": "servant-jsaddle",
+  "branch": "fix-encoding-error",
+  "rev": "2ccf13d185e26d4cb4a51622e748ec64336435f4",
+  "sha256": "066vr1rfq6bjn3xx9g52z2vgp1ibyz50z3hzwaqq3fzxnr2srpjs"
+}

--- a/frontend/src/Frontend/UI/Transfer.hs
+++ b/frontend/src/Frontend/UI/Transfer.hs
@@ -417,20 +417,18 @@ lookupKeySets logL networkName nodes chain accounts = do
   (result, trigger) <- newTriggerEvent
   let envs = mkClientEnvs nodes chain
   liftJSM $ forkJSM $ do
-    r <- doReqFailover envs (Api.local Api.apiV1Client cmd) >>= \rawRes -> do
-      liftIO $ print rawRes
-      case rawRes of
-        Left _ -> pure Nothing
-        Right cr -> case Pact._crResult cr of
-          Pact.PactResult (Right pv) -> case parseAccountDetails pv of
-            Left _ -> pure Nothing
-            Right balances -> liftIO $ do
-              putLog logL LevelInfo $ "lookupKeysets: success:"
-              putLog logL LevelInfo $ tshow balances
-              pure $ Just balances
-          Pact.PactResult (Left e) -> do
-            putLog logL LevelInfo $ "lookupKeysets failed:" <> tshow e
-            pure Nothing
+    r <- doReqFailover envs (Api.local Api.apiV1Client cmd) >>= \case
+      Left _ -> pure Nothing
+      Right cr -> case Pact._crResult cr of
+        Pact.PactResult (Right pv) -> case parseAccountDetails pv of
+          Left _ -> pure Nothing
+          Right balances -> liftIO $ do
+            putLog logL LevelInfo $ "lookupKeysets: success:"
+            putLog logL LevelInfo $ tshow balances
+            pure $ Just balances
+        Pact.PactResult (Left e) -> do
+          putLog logL LevelInfo $ "lookupKeysets failed:" <> tshow e
+          pure Nothing
 
     liftIO $ trigger r
   pure result

--- a/obApp.nix
+++ b/obApp.nix
@@ -32,7 +32,7 @@ in with obelisk;
        {
           # servant-client-core = servantSrc + "/servant-client-core";
           # servant = servantSrc + "/servant";
-          servant-jsaddle = servantSrc + "/servant-jsaddle";
+          servant-jsaddle = hackGet ./dep/servant-jsaddle;
           jsaddle-warp = hackGet ./dep/jsaddle + /jsaddle-warp; #https://github.com/ghcjs/jsaddle/pull/114
           reflex-dom = reflex-dom-src + "/reflex-dom";
           reflex-dom-core = reflex-dom-src + "/reflex-dom-core";


### PR DESCRIPTION
A bug in servant-jsaddle was preventing Chainweaver from properly handling accounts with Unicode characters.  Fixes issue #632.