### PR TITLE
Fix `nix-build -A deb`

### DIFF
--- a/linux.nix
+++ b/linux.nix
@@ -147,14 +147,15 @@
         fi
       }
 
+      mkdir -p $SHAREDIR/gsettings-schemas
       function copy_gtk_settings() {
         path=$1
         gsettings_path=$path/share/gsettings-schemas
 
         if [ -d $gsettings_path ]; then
-          cp -r $gsettings_path $SHAREDIR/gsettings-schemas
+          cp -r $gsettings_path/. $SHAREDIR/gsettings-schemas/
           for d in $(find $gsettings_path -maxdepth 1 -type d); do
-            wrapperArgs+="--prefix XDG_DATA_DIRS : $SHAREDIR/gsettings-schema/$(basename $d) "
+            wrapperArgs+="--prefix XDG_DATA_DIRS : $SHAREDIR/gsettings-schemas/$(basename $d) "
           done;
         fi
       }


### PR DESCRIPTION
Prior to this fix, you'd get the following error: 
```
cp: cannot create directory '/build/kadena-chainweaver-1/usr/share/chainweaver/gsettings-schemas/gsettings-schemas/gtk+3-3.24.10': Permission denied
```
This is because the first copy of the `gsettings_schemas` dir would create a nested `gsettings_schemas` dir inside that did not allow for writes. When the next iteration of the code attempted to copy over settings from a different output, it would not be able to do so. The most recent update resulted in more than one pkgs with gsettings_schemas, and so this issue came to be.

Additionally, there seems to be a spelling error that likely resulted in the settings not being found at all (`schema` vs `schemas`)