### PR TITLE
Bump to pact 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Chainweaver
+# Chainweaver 
 
 Kadena Chainweaver desktop wallet and web-based playground for the [Pact](https://pact-language.readthedocs.io/en/latest/) language, including support for deployments to backends (blockchains, test servers).
 

--- a/dep/pact/github.json
+++ b/dep/pact/github.json
@@ -1,8 +1,8 @@
 {
   "owner": "kadena-io",
   "repo": "pact",
-  "branch": "doug/sig-data-types",
+  "branch": "master",
   "private": false,
-  "rev": "dc61e2003fdd5a3d449fc63a8f310580fa146cf8",
-  "sha256": "1l4c2z8srb3lyl4rxf8vhlnqfy45bf55ii5xnbjmb3s0c4gl6jbv"
+  "rev": "01d2f73475b1fe4bdc67e615b74055b2db8fa3a2",
+  "sha256": "13kkkzgb3nf8cpx4v39kbwnjnm8z07fh902drwz93ln8ppmdqzbs"
 }

--- a/dep/signing-api/github.json
+++ b/dep/signing-api/github.json
@@ -1,8 +1,8 @@
 {
   "owner": "kadena-io",
   "repo": "signing-api",
-  "branch": "split-swagger",
+  "branch": "jam@bump-pact-version",
   "private": false,
-  "rev": "53fdb6693c40239bd8e1d32d53434d23a4a69d42",
-  "sha256": "1wk4xmx2kpfi44ipgj4gjrj7awcbbbw9bbwyr6xxj2yfw1yjjwyr"
+  "rev": "5d41162c0dc3c541e2649ffc995841dafd6d4d92",
+  "sha256": "104yamzy1sdnkjsjkcqqlz5jm0y03vhq4nqqvbwfcmywav3r66jv"
 }


### PR DESCRIPTION
Bumping pact also requires bumping the signing-api, which used to require an older version of pact to build