### PR TITLE
free-x-chain gas station default

### DIFF
--- a/frontend/src/Frontend/UI/Transfer.hs
+++ b/frontend/src/Frontend/UI/Transfer.hs
@@ -562,9 +562,11 @@ checkReceivingAccount model netInfo ti ty fks tks fromPair = do
       (Just (AccountStatus_Exists (AccountDetails _ g)), Nothing) -> do
         if (_ca_chain $ _ti_fromAccount ti) /= (_ca_chain $ _ti_toAccount ti)
           then do
-            let AccountGuard_KeySetLike (KeySetHeritage ks p _ref) = g
-            let ti2 = ti { _ti_toKeyset = Just $ UserKeyset ks (parseKeysetPred p) }
-            transferDialog model netInfo ti2 ty fks tks fromPair
+            case g of
+              AccountGuard_KeySetLike (KeySetHeritage ks p _ref) ->
+                let ti2 = ti { _ti_toKeyset = Just $ UserKeyset ks (parseKeysetPred p) }
+                in transferDialog model netInfo ti2 ty fks tks fromPair
+              _ -> transferDialog model netInfo ti ty fks tks fromPair
           else
             -- Use transfer, probably show the guard at some point
             -- TODO check well-formedness of all keys in the keyset


### PR DESCRIPTION
Adds `free-x-chain-gas` as the default destination-chain gas payer for accounts that don't yet exist (should i also add for accounts with 0 balance?) . Also sets the gasLimit for these txs at 400. 

Addresses #652 

Additionally patches an incomplete pattern match that was causing a runtime exception, although doesn't exactly _solve_ the underlying problem of selecting a guard parameter for cross-chain transfers to vanity accounts (that already exist) . The most common scenario here is when doing a cross-chain transfer to a gas station. See #670