### PR TITLE
Ship with version 4.8.8 of z3

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -3,12 +3,14 @@ args@{ system ? builtins.currentSystem
 , terms ? { # Accepted terms, conditions, and licenses
       security.acme.acceptTerms = true;
   }
-, obelisk ? (import ./.obelisk/impl { inherit system iosSdkVersion terms; })
-, pkgs ? obelisk.reflex-platform.nixpkgs
+, kpkgs ? import ./dep/kpkgs { inherit system; }  # If you want a custom package set, pass it into
+                                                  # kpkgs arg
+, obelisk ? (import ./.obelisk/impl { inherit system iosSdkVersion terms; inherit (kpkgs) reflex-platform-func;})
 , withHoogle ? false
 }:
 with obelisk;
 let
+  pkgs = obelisk.reflex-platform.nixpkgs;
   # All the versions that the user cares about are here so that they can
   # be changed in one place
   chainweaverVersion = "2.2";
@@ -17,7 +19,7 @@ let
   linuxReleaseNumber = "0";
   ovaReleaseNumber = "0";
 
-  obApp = import ./obApp.nix args;
+  obApp = import ./obApp.nix { inherit obelisk; };
   pactServerModule = import ./pact-server/service.nix;
   sass = pkgs.runCommand "sass" {} ''
     set -eux

--- a/dep/kpkgs/default.nix
+++ b/dep/kpkgs/default.nix
@@ -1,7 +1,2 @@
 # DO NOT HAND-EDIT THIS FILE
-import ((import <nixpkgs> {}).fetchFromGitHub (
-  let json = builtins.fromJSON (builtins.readFile ./github.json);
-  in { inherit (json) owner repo rev sha256;
-       private = json.private or false;
-     }
-))
+import (import ./thunk.nix)

--- a/dep/kpkgs/github.json
+++ b/dep/kpkgs/github.json
@@ -2,6 +2,7 @@
   "owner": "kadena-io",
   "repo": "kpkgs",
   "branch": "remove-kadena-packages",
+  "private": false,
   "rev": "77013d631ea3a7a60a2e9f59780f2ef0799c2b31",
   "sha256": "10amyychixwlcaiiwsb01blgz2a85kn86nb6qr1mc3i8i4x085xw"
 }

--- a/dep/kpkgs/thunk.nix
+++ b/dep/kpkgs/thunk.nix
@@ -1,0 +1,9 @@
+# DO NOT HAND-EDIT THIS FILE
+let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
+  if !fetchSubmodules && !private then builtins.fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
+  } else (import <nixpkgs> {}).fetchFromGitHub {
+    inherit owner repo rev sha256 fetchSubmodules private;
+  };
+  json = builtins.fromJSON (builtins.readFile ./github.json);
+in fetch json

--- a/obApp.nix
+++ b/obApp.nix
@@ -2,12 +2,9 @@
 , iosSdkVersion ? "10.2"
 , withHoogle ? false
 , kpkgs ? import ./dep/kpkgs { inherit system; }
+, obelisk
 }:
 let
-  obelisk = import ./.obelisk/impl {
-    inherit system iosSdkVersion;
-    inherit (kpkgs) reflex-platform-func;
-  };
   pkgs = obelisk.reflex-platform.nixpkgs;
 
   optionalExtension = cond: overlay: if cond then overlay else _: _: {};


### PR DESCRIPTION
We were getting z3 errors in the contracts tab because the older version of z3 that we were using was not able to understand certain models. 4.8.8 is the current version that pact ships with