### PR TITLE
Use older version of glib-networking in kpkgs

### DIFF
--- a/dep/kpkgs/github.json
+++ b/dep/kpkgs/github.json
@@ -1,8 +1,8 @@
 {
   "owner": "kadena-io",
   "repo": "kpkgs",
-  "branch": "jam@older-glib-networking-version",
+  "branch": "master",
   "private": false,
-  "rev": "24725d15821572ae03b93df9e057a1086689afab",
-  "sha256": "05vgcxyjisvs11nlw5k5jzb2yip0fvqswlyxq8rdgikkkzc3zh48"
+  "rev": "763f1763207a02fbf6257bd8e2a8cef2a9f86e1d",
+  "sha256": "1dncp11hn65dvwpqrw3di6hdlykjpgc0w0ii5lvwdziac861ak2n"
 }

--- a/dep/kpkgs/github.json
+++ b/dep/kpkgs/github.json
@@ -1,8 +1,8 @@
 {
   "owner": "kadena-io",
   "repo": "kpkgs",
-  "branch": "remove-kadena-packages",
+  "branch": "jam@older-glib-networking-version",
   "private": false,
-  "rev": "77013d631ea3a7a60a2e9f59780f2ef0799c2b31",
-  "sha256": "10amyychixwlcaiiwsb01blgz2a85kn86nb6qr1mc3i8i4x085xw"
+  "rev": "24725d15821572ae03b93df9e057a1086689afab",
+  "sha256": "05vgcxyjisvs11nlw5k5jzb2yip0fvqswlyxq8rdgikkkzc3zh48"
 }


### PR DESCRIPTION
This patch is a temporary fix that prevents the glib error causing crash on startup