### PR TITLE
Unpad ChainIds when passing them around

### DIFF
--- a/frontend/src/Frontend/UI/Dialogs/Send.hs
+++ b/frontend/src/Frontend/UI/Dialogs/Send.hs
@@ -1109,7 +1109,7 @@ pollNodesForReq model envs requestPair maxPolls waitTime handler =
             --Polling came back empty
             PollingAttempt_NotFound -> do
               liftIO $ threadDelay $ waitTime * 1000 * 1000
-              putLog (model^.logger) LevelWarn $ "Polling iteration " <> tshow (maxPolls - iterations) <> " / "<> tshow maxPolls <> " unsucessful. Trying again in " <> tshow waitTime <> " seconds"
+              putLog (model^.logger) LevelWarn $ "Polling iteration " <> tshow (maxPolls - iterations) <> " / "<> tshow maxPolls <> " unsuccessful. Trying again in " <> tshow waitTime <> " seconds"
               pollNodes $ iterations - 1
      in pollNodes maxPolls
 

--- a/frontend/src/Frontend/UI/Wallet.hs
+++ b/frontend/src/Frontend/UI/Wallet.hs
@@ -345,7 +345,7 @@ uiAccountItem cwKeys startsOpen name accountInfo = do
       False -> pure never
       True -> trAcc $ do
         td blank -- Arrow column
-        td $ text $ "Chain " <> _chainId paddedChain
+        td $ text $ "Chain " <> _chainId chain
         td $ dynText $ maybe "" ownershipText <$> getAccountOwnership cwKeys details
         accStatus <- holdUniqDyn $ _account_status <$> dAccount
         elClass "td" "wallet__table-cell wallet__table-cell-keyset" $ dynText $ ffor accStatus $ \case

--- a/frontend/src/Frontend/UI/Wallet.hs
+++ b/frontend/src/Frontend/UI/Wallet.hs
@@ -33,6 +33,7 @@ module Frontend.UI.Wallet
 ------------------------------------------------------------------------------
 import           Control.Lens
 import           Control.Monad               (when, (<=<))
+import           Control.Error               (headMay)
 import qualified Data.IntMap                 as IntMap
 import           Data.Map                    (Map)
 import qualified Data.Map                    as Map
@@ -270,6 +271,14 @@ padChainId n (ChainId c) =
     Nothing -> ChainId c
     Just _ -> ChainId $ T.replicate (n - T.length c) "0" <> c
 
+unPadChainId :: ChainId -> ChainId
+unPadChainId (ChainId c) = if T.length c <= 1 then ChainId c else
+  case headMay (T.unpack c) of
+    -- recurse for when we have padded chain-lengths > 3
+    -- Ex: 0001
+    Just '0' -> unPadChainId $ ChainId $ T.tail c
+    _ -> ChainId c
+
 uiAccountItem
   :: forall key t m. MonadWidget t m
   => Dynamic t (KeyStorage key)
@@ -295,6 +304,7 @@ uiAccountItem cwKeys startsOpen name accountInfo = do
     v0 <- sample $ current startsOpen
     visible <- toggle v0 clk
     results <- accursedUnutterableListWithKey orderedChainMap $ accountRow visible
+
     let balances :: Dynamic t [Maybe AccountBalance]
         balances = fmap Map.elems $ joinDynThroughMap $ (fmap . fmap) fst results
   let dialogs = switch $ leftmost . fmap snd . Map.elems <$> current results
@@ -324,7 +334,8 @@ uiAccountItem cwKeys startsOpen name accountInfo = do
     -> ChainId
     -> Dynamic t Account
     -> m (Dynamic t (Maybe AccountBalance), Event t AccountDialog)
-  accountRow visible chain dAccount = do
+  accountRow visible paddedChain dAccount = do
+    let chain = unPadChainId paddedChain
     let details = (^? account_status . _AccountStatus_Exists) <$> dAccount
     let balance = _accountDetails_balance <$$> details
     -- Previously we always added all chain rows, but hid them with CSS. A bug
@@ -334,7 +345,7 @@ uiAccountItem cwKeys startsOpen name accountInfo = do
       False -> pure never
       True -> trAcc $ do
         td blank -- Arrow column
-        td $ text $ "Chain " <> _chainId chain
+        td $ text $ "Chain " <> _chainId paddedChain
         td $ dynText $ maybe "" ownershipText <$> getAccountOwnership cwKeys details
         accStatus <- holdUniqDyn $ _account_status <$> dAccount
         elClass "td" "wallet__table-cell wallet__table-cell-keyset" $ dynText $ ffor accStatus $ \case


### PR DESCRIPTION
We were using padded chain ids so that they would sort properly, but we never unpadded them before propagating them back through our app. This resulted in using the wrong lens to persist VanityAccountNotes which resulted in those notes not persisting after pressing the "Done" button