### PR TITLE
Expose nixWrapper and update the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A linux webkitgtk version of chainweaver can be built and run in a number of dif
   - This can be installed with `dpkg -i <deb file>` on ubuntu 18.04
   - Chainweaver should be accessible in the applications menu.
 - Run `nix-build -A chainweaverVM default.nix` to build a virtualbox ova file that runs chainweaver
-- Run `WEBKIT_DISABLE_COMPOSITING_MODE=1 $(nix-build -A nixosExe)/bin/kadena-chainweaver` to run the linux app in nixos.
+- Run `$(nix-build -A nixosWrapper)/bin/kadena-chainweaver-wrapper` to run the linux app in nixos.
 
 ### OVA Release
 

--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,7 @@ let
 in obApp // rec {
   inherit sass;
   inherit (macApp) mac deployMac;
-  inherit (linuxApp) nixosExe deb chainweaverVM chainweaverVMSystem;
+  inherit (linuxApp) nixosExe nixosWrapper deb chainweaverVM chainweaverVMSystem;
 
   server = { hostName, adminEmail, routeHost, enableHttps, version, module ? obelisk.serverModules.mkBaseEc2 }@args:
     let


### PR DESCRIPTION
Following literally the instructions in the readme for the NixOS
installation, ie:

```
Run `WEBKIT_DISABLE_COMPOSITING_MODE=1 $(nix-build -A nixosExe)/bin/kadena-chainweaver` to run the linux app in nixos.
```

The resulting app won't be able to connect to testnet and mainnet
because of a problem with certificates. The solution is already present
in the repo, but not exposed to the users; in the linux.nix file, we
read:

```
  nixosWrapper = pkgs.writeScriptBin "${linuxAppName}-wrapper" ''
    #!/usr/bin/env bash
    WEBKIT_DISABLE_COMPOSITING_MODE=1 NIX_SSL_CERT_FILE=${nixosExe}/bin/ca-certificates-patched.crt ${nixosExe}/bin/${linuxAppName}
  '';
```

which fixes bot the webkit problem and the issue with certificates.

This PR exposes the option to build nixosWrapper from the `default.nix`
file, and documents it in the README as the preferred way of building
chainweaver under NixOS.