### PR TITLE
Fix Issue #636 on Ubuntu

### DIFF
--- a/linux/src/Linux.hs
+++ b/linux/src/Linux.hs
@@ -175,4 +175,4 @@ resizeWindow _ _ = do
   pure ()
 
 getHomeDirectory :: IO String
-getHomeDirectory = PU.getLoginName >>= fmap PU.homeDirectory . PU.getUserEntryForName
+getHomeDirectory = PU.getEffectiveUserName >>= fmap PU.homeDirectory . PU.getUserEntryForName


### PR DESCRIPTION
instead of getLoginName, use getEffectiveUserName to properly get the name of the user associated to the logged in User ID

see:  https://github.com/kadena-io/chainweaver/issues/636