### PR TITLE
Remove usage of system-locale from frontend as it does not work on web

### DIFF
--- a/frontend/frontend.cabal
+++ b/frontend/frontend.cabal
@@ -87,7 +87,6 @@ library
     , servant-jsaddle
     , split
     , string-qq
-    , system-locale
     , template-haskell
     , text
     , th-extras


### PR DESCRIPTION
The usage of locale was for formatting the time for logging, which perhaps does not justify adding the complexity of #ifdef to support the !GHCJS_HOST_OS.