### PR TITLE
Hash mismatch correction

### DIFF
--- a/frontend/src/Frontend/UI/Dialogs/KeyDetails.hs
+++ b/frontend/src/Frontend/UI/Dialogs/KeyDetails.hs
@@ -43,7 +43,6 @@ import           Reflex.Dom hiding (Command, Key)
 import           Frontend.Crypto.Class
 import           Frontend.Foundation
 import           Frontend.UI.Modal
-import           Frontend.UI.Transfer
 import           Frontend.UI.Widgets
 import           Frontend.UI.Widgets.Helpers (dialogSectionHeading)
 import           Frontend.Wallet


### PR DESCRIPTION
In this PR, instead of encoding the decoded payload, which caused incorrect hashes to be generated, we directly hash the user input.