### PR TITLE
Removed ghcjs specific code

### DIFF
--- a/dep/juicy.pixels.ghcjs/default.nix
+++ b/dep/juicy.pixels.ghcjs/default.nix
@@ -1,0 +1,2 @@
+# DO NOT HAND-EDIT THIS FILE
+import (import ./thunk.nix)

--- a/dep/juicy.pixels.ghcjs/github.json
+++ b/dep/juicy.pixels.ghcjs/github.json
@@ -1,0 +1,7 @@
+{
+  "owner": "obsidiansystems",
+  "repo": "juicy.pixels.ghcjs",
+  "private": false,
+  "rev": "a1c516493c674dba64e8eadb8a65b829477f302d",
+  "sha256": "06dm7kw5p1df0j0mf2wp9yyqxxzx9lih1y3l2ym8dcl1cklrnx57"
+}

--- a/dep/juicy.pixels.ghcjs/thunk.nix
+++ b/dep/juicy.pixels.ghcjs/thunk.nix
@@ -1,0 +1,9 @@
+# DO NOT HAND-EDIT THIS FILE
+let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
+  if !fetchSubmodules && !private then builtins.fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
+  } else (import <nixpkgs> {}).fetchFromGitHub {
+    inherit owner repo rev sha256 fetchSubmodules private;
+  };
+  json = builtins.fromJSON (builtins.readFile ./github.json);
+in fetch json

--- a/dep/qrcode/default.nix
+++ b/dep/qrcode/default.nix
@@ -1,0 +1,2 @@
+# DO NOT HAND-EDIT THIS FILE
+import (import ./thunk.nix)

--- a/dep/qrcode/github.json
+++ b/dep/qrcode/github.json
@@ -1,0 +1,7 @@
+{
+  "owner": "obsidiansystems",
+  "repo": "qrcode",
+  "private": false,
+  "rev": "91e6bb9954af52a422ff9a5d9cf45cb9601aece6",
+  "sha256": "01ynclz6vpih37j8hbjdsf57s3pddps44zp2f90hjihf8sg7pa4f"
+}

--- a/dep/qrcode/github.json
+++ b/dep/qrcode/github.json
@@ -1,7 +1,8 @@
 {
   "owner": "obsidiansystems",
   "repo": "qrcode",
+  "branch": "master",
   "private": false,
-  "rev": "91e6bb9954af52a422ff9a5d9cf45cb9601aece6",
-  "sha256": "01ynclz6vpih37j8hbjdsf57s3pddps44zp2f90hjihf8sg7pa4f"
+  "rev": "f33abef0451982ae7769b24e9031753ef2c4d826",
+  "sha256": "044bi6fnrzpzam0zyd6yijpkphjnn3z751nnxb3zz2w93wzi6nkd"
 }

--- a/dep/qrcode/thunk.nix
+++ b/dep/qrcode/thunk.nix
@@ -1,0 +1,9 @@
+# DO NOT HAND-EDIT THIS FILE
+let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
+  if !fetchSubmodules && !private then builtins.fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
+  } else (import <nixpkgs> {}).fetchFromGitHub {
+    inherit owner repo rev sha256 fetchSubmodules private;
+  };
+  json = builtins.fromJSON (builtins.readFile ./github.json);
+in fetch json

--- a/frontend/frontend.cabal
+++ b/frontend/frontend.cabal
@@ -105,14 +105,11 @@ library
     , unordered-containers
     , vector
     , witherable
+    , qrcode-juicypixels
 
   if impl(ghcjs)
     build-depends:
         ghcjs-base
-
-  if !impl(ghcjs)
-    build-depends:
-        qrcode-juicypixels
 
   exposed-modules: Frontend
                  , Frontend.AppCfg

--- a/frontend/src/Frontend/UI/Dialogs/KeyDetails.hs
+++ b/frontend/src/Frontend/UI/Dialogs/KeyDetails.hs
@@ -11,10 +11,8 @@ module Frontend.UI.Dialogs.KeyDetails
   ) where
 
 ------------------------------------------------------------------------------
-#if !defined(ghcjs_HOST_OS)
 import qualified Codec.QRCode as QR
 import qualified Codec.QRCode.JuicyPixels as QR
-#endif
 import           Control.Error
 import           Control.Lens
 import           Control.Monad (join)
@@ -245,12 +243,10 @@ uiKeyDetails _keyIndex key _onCloseExternal = mdo
           Nothing -> blank
           Just sig' -> do
             uiDetailsCopyButton $ current sig'
-#if !defined(ghcjs_HOST_OS)
             let qrImage = QR.encodeText (QR.defaultQRCodeOptions QR.L) QR.Iso8859_1OrUtf8WithECI <$> sig'
-                img = maybe "Error creating QR code" (QR.toPngDataUrlT 4 6) <$> qrImage
+                img = maybe "Error creating QR code" (QR.toBmpDataUrlT 4 6) <$> qrImage
             el "br" blank
             elDynAttr "img" (("src" =:) . LT.toStrict <$> img) blank
-#endif
 
   modalFooter $ do
     onDone <- confirmButton def "Done"

--- a/frontend/src/Frontend/UI/Transfer.hs
+++ b/frontend/src/Frontend/UI/Transfer.hs
@@ -60,10 +60,8 @@ import           Data.These (These(This))
 import           Data.Traversable
 import           Data.Time.Clock.POSIX
 
-#if !defined(ghcjs_HOST_OS)
 import qualified Codec.QRCode as QR
 import qualified Codec.QRCode.JuicyPixels as QR
-#endif
 import qualified Data.YAML.Aeson as Y
 
 import           Pact.Types.SigData
@@ -1484,11 +1482,10 @@ transferDetails signedCmd = do
           & initialAttributes %~ (<> "disabled" =: "" <> "style" =: "width: 100%; height: 18em;")
           & textAreaElementConfig_setValue .~ updated preview
 
-#if !defined(ghcjs_HOST_OS)
       tabPane mempty curSelection TransferDetails_HashQR $ do
         let hashText = hashToText . toUntypedHash . _sigDataHash <$> signedCmd
             qrImage = QR.encodeText (QR.defaultQRCodeOptions QR.L) QR.Iso8859_1OrUtf8WithECI <$> hashText
-            img = maybe "Error creating QR code" (QR.toPngDataUrlT 4 6) <$> qrImage
+            img = maybe "Error creating QR code" (QR.toBmpDataUrlT 4 6) <$> qrImage
         el "div" $ text $ T.unwords
           [ "This QR code contains only the request key."
           , "It doesn't give any transaction information, so some wallets may not accept it."
@@ -1499,13 +1496,8 @@ transferDetails signedCmd = do
       tabPane mempty curSelection TransferDetails_FullQR $ do
         let yamlText = T.decodeUtf8 . Y.encode1Strict <$> signedCmd
             qrImage = QR.encodeText (QR.defaultQRCodeOptions QR.L) QR.Iso8859_1OrUtf8WithECI <$> yamlText
-            img = maybe "Error creating QR code" (QR.toPngDataUrlT 4 4) <$> qrImage
+            img = maybe "Error creating QR code" (QR.toBmpDataUrlT 4 4) <$> qrImage
         elDynAttr "img" (("src" =:) . LT.toStrict <$> img) blank
-#else
-      let notAvailMsg = el "ul" $ text "This feature is not currently available in the browser"
-      tabPane mempty curSelection TransferDetails_HashQR notAvailMsg
-      tabPane mempty curSelection TransferDetails_FullQR notAvailMsg
-#endif
 
       pure ()
 

--- a/obApp.nix
+++ b/obApp.nix
@@ -46,6 +46,7 @@ in with obelisk;
           obelisk-oauth-frontend = hackGet ./dep/obelisk-oauth + /frontend;
           obelisk-oauth-backend = hackGet ./dep/obelisk-oauth + /backend;
           HsYAML-aeson = hackGet ./dep/HsYAML-aeson;
+          qrcode-juicypixels = hackGet ./dep/qrcode + "/qrcode-juicypixels";
 
           # Needed for obelisk-oauth currently (ghcjs support mostly):
           entropy = hackGet ./dep/entropy;

--- a/obApp.nix
+++ b/obApp.nix
@@ -46,6 +46,7 @@ in with obelisk;
           obelisk-oauth-frontend = hackGet ./dep/obelisk-oauth + /frontend;
           obelisk-oauth-backend = hackGet ./dep/obelisk-oauth + /backend;
           HsYAML-aeson = hackGet ./dep/HsYAML-aeson;
+          JuicyPixels-ghcjs = hackGet ./../juicy.pixels.ghcjs;
           qrcode-juicypixels = hackGet ./dep/qrcode + "/qrcode-juicypixels";
 
           # Needed for obelisk-oauth currently (ghcjs support mostly):

--- a/obApp.nix
+++ b/obApp.nix
@@ -46,7 +46,7 @@ in with obelisk;
           obelisk-oauth-frontend = hackGet ./dep/obelisk-oauth + /frontend;
           obelisk-oauth-backend = hackGet ./dep/obelisk-oauth + /backend;
           HsYAML-aeson = hackGet ./dep/HsYAML-aeson;
-          JuicyPixels-ghcjs = hackGet ./../juicy.pixels.ghcjs;
+          JuicyPixels-ghcjs = hackGet ./dep/juicy.pixels.ghcjs;
           qrcode-juicypixels = hackGet ./dep/qrcode + "/qrcode-juicypixels";
 
           # Needed for obelisk-oauth currently (ghcjs support mostly):


### PR DESCRIPTION
Removed the dependency on juicypixels as a whole, by keeping the `encodeBitmap` function from juicypixels into our fork of `qrcode-juicypixels`(maybe we should rename this, since it is not dependent on juicypixels anymore).