### PR TITLE
Reduce concurrency without obelisk bump

### DIFF
--- a/dep/kpkgs/github.json
+++ b/dep/kpkgs/github.json
@@ -1,8 +1,8 @@
 {
-  "owner": "kadena-io",
+  "owner": "obsidiansystems",
   "repo": "kpkgs",
-  "branch": "master",
+  "branch": "cn/remove-more-tests-from-libuv",
   "private": false,
-  "rev": "763f1763207a02fbf6257bd8e2a8cef2a9f86e1d",
-  "sha256": "1dncp11hn65dvwpqrw3di6hdlykjpgc0w0ii5lvwdziac861ak2n"
+  "rev": "63e279f4abf09db372bea0b4332cf8473a5dc857",
+  "sha256": "06vp26y3x50fs1k6ziplnb7bl316r6zl0jn1zpl7yz0kgbc89za3"
 }

--- a/frontend/src/Frontend/Network.hs
+++ b/frontend/src/Frontend/Network.hs
@@ -353,7 +353,7 @@ getNodeInfosAsync
   => [NodeRef]
   -> ((NodeRef, Either Text NodeInfo) -> IO ())
   -> m ()
-getNodeInfosAsync nodes cb = for_ nodes $ \nodeRef -> void $ liftJSM $ forkJSM $ do
+getNodeInfosAsync nodes cb = liftJSM $ forkJSM $ for_ nodes $ \nodeRef -> void $ do
   r <- discoverNode nodeRef
   liftIO $ cb (nodeRef, r)
 


### PR DESCRIPTION
These are the same changes done for reducing the amount of XHR to solve the freeze problem on newer versions of macOS but without the obelisk bump. However, there's still a minor upgrade in kpkgs, needed to fix the build (relaxing some tests in libuv).