### PR TITLE
Fix TTL widget

### DIFF
--- a/frontend/src/Frontend/UI/DeploymentSettings.hs
+++ b/frontend/src/Frontend/UI/DeploymentSettings.hs
@@ -685,7 +685,7 @@ uiMetaData m mTTL mGasLimit = do
       Just _ -> pure never
       Nothing -> tag (current $ fmap _pmTTL $ m ^. network_meta) <$> getPostBuild
     let secondsInDay = 60 * 60 * 24
-        secondsInMonth = 30 * secondsInDay
+        maxTTL = secondsInDay * 2
         minTTL = 60
         prettyTTL s = tshow s <> case s of
           1 -> " second"
@@ -698,7 +698,7 @@ uiMetaData m mTTL mGasLimit = do
           sliderEl <- uiSlider "" (text $ prettyTTL minTTL) (text "1 day") $ conf
             & initialAttributes .~ "min" =: (tshow minTTL) <> "max" =: T.pack (show secondsInDay) <> "step" =: "1"
             & inputElementConfig_setValue .~ _inputElement_input inputEl
-          (inputEl, inputEv) <- dimensionalInputFeedbackWrapper (Just "Seconds") $ uiIntInputElement (Just minTTL) (Just secondsInMonth) $ conf
+          (inputEl, inputEv) <- dimensionalInputFeedbackWrapper (Just "Seconds") $ uiIntInputElement (Just minTTL) (Just maxTTL) $ conf
             & inputElementConfig_setValue .~ _inputElement_input sliderEl
             & inputElementConfig_elementConfig . elementConfig_eventSpec %~ preventUpAndDownArrow @m
           preventScrollWheel $ _inputElement_raw inputEl

--- a/frontend/src/Frontend/UI/DeploymentSettings.hs
+++ b/frontend/src/Frontend/UI/DeploymentSettings.hs
@@ -685,6 +685,7 @@ uiMetaData m mTTL mGasLimit = do
       Just _ -> pure never
       Nothing -> tag (current $ fmap _pmTTL $ m ^. network_meta) <$> getPostBuild
     let secondsInDay = 60 * 60 * 24
+        secondsInMonth = 30 * secondsInDay
         minTTL = 60
         prettyTTL s = tshow s <> case s of
           1 -> " second"
@@ -693,12 +694,11 @@ uiMetaData m mTTL mGasLimit = do
         initTTL = fromMaybe defaultTransactionTTL mTTL
         ttlInput cls = elKlass "div" cls $ mdo
           let conf = def
-                & initialAttributes .~ "min" =: prettyTTL minTTL <> "max" =: T.pack (show secondsInDay) <> "step" =: "1"
-                & inputElementConfig_setValue .~ fmap showTtl pbTTL
                 & inputElementConfig_initialValue .~ showTtl initTTL
           sliderEl <- uiSlider "" (text $ prettyTTL minTTL) (text "1 day") $ conf
+            & initialAttributes .~ "min" =: (tshow minTTL) <> "max" =: T.pack (show secondsInDay) <> "step" =: "1"
             & inputElementConfig_setValue .~ _inputElement_input inputEl
-          (inputEl, inputEv) <- dimensionalInputFeedbackWrapper (Just "Seconds") $ uiIntInputElement (Just minTTL) (Just secondsInDay) $ conf
+          (inputEl, inputEv) <- dimensionalInputFeedbackWrapper (Just "Seconds") $ uiIntInputElement (Just minTTL) (Just secondsInMonth) $ conf
             & inputElementConfig_setValue .~ _inputElement_input sliderEl
             & inputElementConfig_elementConfig . elementConfig_eventSpec %~ preventUpAndDownArrow @m
           preventScrollWheel $ _inputElement_raw inputEl


### PR DESCRIPTION
Fixes the ttl widget in gtransfer so that:
- Setting the ttl slider to minimum results in the value being set to 60, no 0
- The user can manually set a value greater than the maximum value of the slider by using the input widget