### PR TITLE
Enable overflow for Settings, and Resources pages

### DIFF
--- a/backend/sass/common.blocks/_page.scss
+++ b/backend/sass/common.blocks/_page.scss
@@ -30,7 +30,6 @@
   position: relative;
   width: 100%;
   flex: 1;
-  overflow: hidden;
 }
 
 .page__content {


### PR DESCRIPTION
(This class is used in Contracts as well, but this change does not seem to affect its UI.)

Problem: The view looks like this when the icons are small

![2022-03-31-143828_screenshot](https://user-images.githubusercontent.com/681060/160984253-b01caee5-ce99-480e-bd2e-507d23fda8e2.png)

But just increasing the window size slightly causes this, and there is no way for the user to scroll down.
![2022-03-31-143846_screenshot](https://user-images.githubusercontent.com/681060/160984329-39730d03-f98e-4955-8c25-6ca8dcc4e153.png)

This fix allows the user to scroll down

![2022-03-31-144244_screenshot](https://user-images.githubusercontent.com/681060/160984605-13a457f4-4667-4587-a99b-c7b087ac957e.png)

![2022-03-31-144343_screenshot](https://user-images.githubusercontent.com/681060/160984661-8b32168d-7591-4118-ba9b-95a7578575a5.png)
