### PR TITLE
Reference correct button '+ Watch Account' 

### DIFF
--- a/frontend/src/Frontend/UI/Wallet.hs
+++ b/frontend/src/Frontend/UI/Wallet.hs
@@ -180,7 +180,7 @@ uiAccountsTable model dStartOpen = do
     Nothing -> uiEmptyState (static @"img/menu/wallet.svg") "No Accounts Found" $ do
       el "p" $ do
         text "Create new Accounts or interact with existing Accounts by selecting the "
-        el "strong" $ text "+ Add Account"
+        el "strong" $ text "+ Watch Account"
         text " button."
       pure mempty
     Just m -> divClass "wallet__keys-list" $ uiAccountItems model m dStartOpen


### PR DESCRIPTION
Accounts page text, in case no account is found, references to the `+ Add Account` button. The button is actually called `+ Watch Account`.

![image](https://user-images.githubusercontent.com/26225067/207959748-f3b06470-3779-4d9d-a55c-088ced9e327f.png)
