### PR TITLE
Deduplicate response-sending events in quickSign

### DIFF
--- a/frontend/src/Frontend/UI/Dialogs/Signing.hs
+++ b/frontend/src/Frontend/UI/Dialogs/Signing.hs
@@ -134,6 +134,8 @@ uiSigning ideL (signingRequest, writeSigningResponse) onCloseExternal = do
         }
 
 -- | Ask user for confirmation before deleting "something".
+--   TODO: This comment seems wrong.
+--   What is the output event?
 --
 -- At the moment "something" is only keys, so we skip making "something"
 -- configurable for now.
@@ -220,7 +222,7 @@ quickSignModal ideL writeSigningResponse payloads externalClose = fmap switchPro
     (reject, sign) <- modalFooter $ (,)
       <$> cancelButton def "Reject"
       <*> confirmButton def "Sign All"
-    let noResponseEv = ffor (leftmost [reject, onClose, externalClose]) $
+    noResponseEv <- headE $ ffor (leftmost [ reject , onClose , externalClose]) $
           const $ QSR_Error QuicksignError_Reject
     res <- writeSigningResponse noResponseEv
     pure (res, handleSigning payloads writeSigningResponse keysAndNet <$ sign)

--- a/frontend/src/Frontend/UI/Dialogs/Signing.hs
+++ b/frontend/src/Frontend/UI/Dialogs/Signing.hs
@@ -222,7 +222,7 @@ quickSignModal ideL writeSigningResponse payloads externalClose = fmap switchPro
     (reject, sign) <- modalFooter $ (,)
       <$> cancelButton def "Reject"
       <*> confirmButton def "Sign All"
-    noResponseEv <- headE $ ffor (leftmost [ reject , onClose , externalClose]) $
+    noResponseEv <- headE $ ffor (leftmost [reject, onClose, externalClose]) $
           const $ QSR_Error QuicksignError_Reject
     res <- writeSigningResponse noResponseEv
     pure (res, handleSigning payloads writeSigningResponse keysAndNet <$ sign)


### PR DESCRIPTION
Our code for interpreting HTTP requests relies on MVarHandler, which assumes one response is generated per request. When this assumption is violated, MVar invariants get broken and we see deadlocks.

For reasons we still don't understand, any event that causes the QuickSign modal to close without issuing a positive signal to sign its transaction produces an extra modal-close event.

Each modal-close event gets mapped to an HTTP response, and this PUTs to the same MVar twice without an intervening TAKE.

This commit fixes the issue by simply deduplicating close events.

A more principled solution would have removed the source of the duplicated close events upstream, but it was not trivial to figure out. So we have a stopgap.

## Testing done

 - Manually run chainweaver native app
 - Use `kda wallet-sign` to issue signing commands and raise the QuickSign modal
 - Close it with `Reject`
 - Confirm `kda` acknowledges the rejection.
 - Repeat for `X` button.
 - Repeat for `Esc` key.
 - Repeat again for `Reject`, `X`, and `Esc`.
 - Confirm UI is still responsive to switching tabs.
 - Issue another `kda wallet-sign` and accept.
 - Confirm UI is still responsive.
 - One more `kda wallet-sign` and `Reject` and confirm UI responsive for good measure.